### PR TITLE
feat: expose OpenCode createOpencodeClient configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No changes yet.
 
+## [2.1.0] - 2026-02-18
+
+### Added
+
+- **SDK client passthrough options** - Added `clientOptions` on `OpencodeProviderSettings` to forward OpenCode `createOpencodeClient()` configuration (headers, auth, fetch, serializers, validators, transformers, throwOnError, and RequestInit-compatible options).
+- **Preconfigured client support** - Added `client` on `OpencodeProviderSettings` to use a prebuilt OpenCode SDK client directly.
+- **Client configuration example** - Added `examples/client-options.ts` showing `clientOptions` passthrough and preconfigured `client` usage patterns.
+
+### Changed
+
+- **Client initialization behavior** - `clientOptions` are now applied consistently across external `baseUrl`, existing-server, and auto-started-server client creation paths.
+- **Conflict handling** - Reserved `baseUrl` and `directory` values in `clientOptions` are ignored with warnings; `client` takes precedence over `clientOptions`.
+
 ## [2.0.0] - 2026-02-13
 
 - **Breaking release** - OpenCode SDK v2 migration and AI SDK v6 hardening.

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ for await (const part of result.fullStream) {
 - `examples/abort-signal.ts` - Cancellation patterns for generate and stream calls.
 - `examples/image-input.ts` - File/image input using base64 or data URLs.
 - `examples/custom-config.ts` - Provider/model configuration and reliability controls.
+- `examples/client-options.ts` - `clientOptions` passthrough and preconfigured `client` patterns.
 - `examples/limitations.ts` - Practical limitations and expected behaviors.
 - `examples/long-running-tasks.ts` - Patterns for longer tasks and retries.
 
@@ -277,8 +278,41 @@ interface OpencodeProviderSettings {
   baseUrl?: string; // Override full URL
   autoStartServer?: boolean; // Default: true
   serverTimeout?: number; // Default: 10000
+  clientOptions?: OpencodeClientOptions; // Pass-through to createOpencodeClient()
+  client?: OpencodeClient; // Preconfigured SDK client (bypasses server management)
   defaultSettings?: OpencodeSettings;
 }
+```
+
+`clientOptions` forwards OpenCode SDK client configuration such as:
+
+- `headers` (custom HTTP headers)
+- `fetch` (custom fetch implementation)
+- `auth` (token or auth function)
+- `bodySerializer` / `querySerializer`
+- `requestValidator` / `responseValidator` / `responseTransformer`
+- `throwOnError`
+- standard `RequestInit` fields (`credentials`, `mode`, `cache`, `signal`, etc.)
+
+Notes:
+
+- `baseUrl` and `directory` remain provider/model managed (`baseUrl` at provider level, `directory` via `defaultSettings` or per-model settings).
+- If both `client` and `clientOptions` are provided, `client` takes precedence.
+- If `client` is provided, its lifecycle remains caller-managed; `dispose()` only cleans up provider-managed server processes.
+
+Example:
+
+```typescript
+const opencode = createOpencode({
+  baseUrl: "http://127.0.0.1:4096",
+  clientOptions: {
+    headers: {
+      "x-api-key": process.env.OPENCODE_API_KEY ?? "",
+    },
+    credentials: "include",
+    throwOnError: true,
+  },
+});
 ```
 
 ## Model Settings

--- a/examples/client-options.ts
+++ b/examples/client-options.ts
@@ -1,0 +1,73 @@
+import { generateText } from "ai";
+import { createOpencode } from "../dist/index.js";
+import { createOpencodeClient } from "@opencode-ai/sdk/v2";
+
+const MODEL = "openai/gpt-5.3-codex-spark";
+const BASE_URL = "http://127.0.0.1:4096";
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function runStep(title: string, fn: () => Promise<void>) {
+  console.log(title);
+  try {
+    await fn();
+  } catch (error) {
+    console.error(`  Error: ${formatError(error)}`);
+  }
+  console.log();
+}
+
+async function main() {
+  console.log("=== OpenCode: clientOptions and preconfigured client ===");
+  console.log("This example assumes an OpenCode server is available at", BASE_URL);
+  console.log();
+
+  const providerWithClientOptions = createOpencode({
+    baseUrl: BASE_URL,
+    clientOptions: {
+      headers: {
+        "x-demo-source": "client-options-example",
+      },
+      credentials: "include",
+      throwOnError: true,
+    },
+  });
+
+  await runStep("1) Provider with clientOptions passthrough", async () => {
+    const { text } = await generateText({
+      model: providerWithClientOptions(MODEL),
+      prompt: 'Reply with exactly: "client-options-ok".',
+    });
+    console.log(`  Response: ${text}`);
+  });
+
+  const preconfiguredClient = await createOpencodeClient({
+    baseUrl: BASE_URL,
+    headers: {
+      "x-demo-source": "preconfigured-client-example",
+    },
+    throwOnError: true,
+  });
+
+  const providerWithPreconfiguredClient = createOpencode({
+    client: preconfiguredClient,
+  });
+
+  await runStep("2) Provider with preconfigured SDK client", async () => {
+    const { text } = await generateText({
+      model: providerWithPreconfiguredClient(MODEL),
+      prompt: 'Reply with exactly: "preconfigured-client-ok".',
+    });
+    console.log(`  Response: ${text}`);
+  });
+
+  await providerWithClientOptions.dispose?.();
+  await providerWithPreconfiguredClient.dispose?.();
+}
+
+main().catch((error) => {
+  console.error("Error:", error);
+  process.exitCode = 1;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-opencode-sdk",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "AI SDK v6 provider for OpenCode via @opencode-ai/sdk",
   "keywords": [
     "ai-sdk",
@@ -52,7 +52,8 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "example:basic": "npm run build && npx tsx examples/basic-usage.ts",
-    "example:streaming": "npm run build && npx tsx examples/streaming.ts"
+    "example:streaming": "npm run build && npx tsx examples/streaming.ts",
+    "example:client-options": "npm run build && npx tsx examples/client-options.ts"
   },
   "dependencies": {
     "@ai-sdk/provider": "^3.0.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ export type { ClientManagerOptions } from "./opencode-client-manager.js";
 // Type exports
 export type {
   OpencodeModelId,
+  OpencodeClient,
+  OpencodeCreateClientOptions,
+  OpencodeClientOptions,
   OpencodeSettings,
   OpencodeProviderSettings,
   OpencodeProvider,

--- a/src/opencode-provider.ts
+++ b/src/opencode-provider.ts
@@ -41,12 +41,7 @@ export function createOpencode(
   const logger = getLogger(options?.defaultSettings?.logger);
 
   // Validate provider settings
-  const { warnings } = validateProviderSettings(options, logger);
-
-  // Log any validation warnings
-  for (const warning of warnings) {
-    logger.warn(warning);
-  }
+  validateProviderSettings(options, logger);
 
   // Create client manager
   const clientManager = createClientManagerFromSettings(options ?? {}, logger);

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,29 @@ import type { LanguageModelV3, ProviderV3 } from "@ai-sdk/provider";
 export type OpencodeModelId = string;
 
 /**
+ * OpenCode SDK client instance.
+ */
+export type OpencodeClient = Awaited<
+  ReturnType<typeof import("@opencode-ai/sdk/v2").createOpencodeClient>
+>;
+
+/**
+ * Full createOpencodeClient() options from OpenCode SDK.
+ */
+export type OpencodeCreateClientOptions = NonNullable<
+  Parameters<typeof import("@opencode-ai/sdk/v2").createOpencodeClient>[0]
+>;
+
+/**
+ * Provider passthrough options for createOpencodeClient().
+ * baseUrl and directory are managed by provider settings and model settings.
+ */
+export type OpencodeClientOptions = Omit<
+  OpencodeCreateClientOptions,
+  "baseUrl" | "directory"
+>;
+
+/**
  * Logger interface for the OpenCode provider.
  */
 export interface Logger {
@@ -152,6 +175,22 @@ export interface OpencodeProviderSettings {
    * @default 10000
    */
   serverTimeout?: number;
+
+  /**
+   * Additional createOpencodeClient() options to pass through to the SDK.
+   * Use this for custom headers, auth, fetch, serializers, validators,
+   * transformers, throwOnError, and RequestInit-compatible options.
+   *
+   * `baseUrl` and `directory` are managed by provider/model settings.
+   */
+  clientOptions?: OpencodeClientOptions;
+
+  /**
+   * Preconfigured OpenCode SDK client instance.
+   * When provided, this client is used directly and server management is
+   * bypassed.
+   */
+  client?: OpencodeClient;
 
   /**
    * Default settings applied to all model instances.

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -57,6 +57,8 @@ export const opcodeProviderSettingsSchema = z.object({
   baseUrl: z.string().url().optional(),
   autoStartServer: z.boolean().optional(),
   serverTimeout: z.number().int().positive().optional(),
+  clientOptions: z.record(z.string(), z.unknown()).optional(),
+  client: z.object({}).passthrough().optional(),
   defaultSettings: opcodeSettingsSchema.optional(),
 });
 
@@ -153,6 +155,26 @@ export function validateProviderSettings(
     warnings.push(
       `Server timeout ${settings.serverTimeout}ms is very short, consider at least 5000ms`,
     );
+  }
+
+  if (settings.client && settings.clientOptions) {
+    warnings.push(
+      "Both client and clientOptions were provided; clientOptions will be ignored because client takes precedence",
+    );
+  }
+
+  if (settings.clientOptions) {
+    const options = settings.clientOptions as Record<string, unknown>;
+    if (options.baseUrl !== undefined) {
+      warnings.push(
+        "clientOptions.baseUrl is ignored; use provider baseUrl or hostname/port instead",
+      );
+    }
+    if (options.directory !== undefined) {
+      warnings.push(
+        "clientOptions.directory is ignored; use defaultSettings.directory or per-model directory instead",
+      );
+    }
   }
 
   // Log warnings if logger is provided


### PR DESCRIPTION
## Summary

Closes #5.

- **`clientOptions`** passthrough on `OpencodeProviderSettings` to forward `createOpencodeClient()` configuration (headers, auth, fetch, serializers, validators, transformers, `throwOnError`, and `RequestInit`-compatible options)
- **`client`** option to inject a preconfigured OpenCode SDK client directly, bypassing server management
- Manager-owned `baseUrl` and `directory` are enforced with clear warnings if overridden in `clientOptions`

## Test plan

- [x] 321 unit tests passing (3 new test files touched, +612/-28 lines)
- [x] Smoke-tested both `clientOptions` and preconfigured `client` paths at runtime
- [x] Verified reserved-key warnings fire for real values, not for `undefined`
- [x] Verified no duplicate warning logging
- [x] `npm run typecheck`, `npm run lint`, `npm test` all green
- [x] New runnable example: `examples/client-options.ts`