### PR TITLE
fix: streaming deltas + user-role guard + SDK bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No changes yet.
 
+## [2.1.2] - 2026-03-02
+
+### Fixed
+
+- **Streaming delta handling** - Added support for `message.part.delta` events to enable true incremental text and reasoning streaming instead of batch delivery via `message.part.updated` only. (PR [#9](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/pull/9) by [@abhijit-hota](https://github.com/abhijit-hota))
+- **User-message filtering for deltas** - Applied user-role guard to `handlePartDelta` to prevent user prompt text from leaking into assistant stream output, matching existing filtering in `handlePartUpdated`.
+
+### Changed
+
+- **Dependencies** - Bumped `@opencode-ai/sdk` from `^1.1.65` to `^1.2.15`.
+
 ## [2.1.1] - 2026-02-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-opencode-sdk",
-      "version": "2.1.0",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.8",
         "@ai-sdk/provider-utils": "^4.0.15",
-        "@opencode-ai/sdk": "^1.1.65"
+        "@opencode-ai/sdk": "^1.2.15"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -955,9 +955,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.1.65",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.1.65.tgz",
-      "integrity": "sha512-XlpgQJQ5WwO4tYgyyHoTT0NAB5/1StXonabVUAYVpW0JdtbwWFSdFEaLkWx6CU7MNW6ELP+SMC4n6wWO6zRW8Q==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.2.15.tgz",
+      "integrity": "sha512-NUJNlyBCdZ4R0EBLjJziEQOp2XbRPJosaMcTcWSWO5XJPKGUpz0u8ql+5cR8K+v2RJ+hp2NobtNwpjEYfe6BRQ==",
       "license": "MIT"
     },
     "node_modules/@opentelemetry/api": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "AI SDK v6 provider for OpenCode via @opencode-ai/sdk",
   "keywords": [
     "ai-sdk",
@@ -58,7 +58,7 @@
   "dependencies": {
     "@ai-sdk/provider": "^3.0.8",
     "@ai-sdk/provider-utils": "^4.0.15",
-    "@opencode-ai/sdk": "^1.1.65"
+    "@opencode-ai/sdk": "^1.2.15"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/convert-from-opencode-events.test.ts
+++ b/src/convert-from-opencode-events.test.ts
@@ -476,6 +476,27 @@ describe("convert-from-opencode-events", () => {
         expect(state.textStarted).toBe(false);
       });
 
+      it("should filter out deltas from user messages", () => {
+        const state = createStreamState();
+        state.messageRoles.set("user-msg-1", "user");
+
+        const event: EventMessagePartDelta = {
+          type: "message.part.delta",
+          properties: {
+            sessionID: "session-123",
+            messageID: "user-msg-1",
+            partID: "part-1",
+            field: "text",
+            delta: "User prompt that should be filtered",
+          },
+        };
+
+        const parts = convertEventToStreamParts(event, state);
+
+        expect(parts).toHaveLength(0);
+        expect(state.textStarted).toBe(false);
+      });
+
       it("should handle reasoning-end then reasoning-start when reasoning part ID changes", () => {
         const state = createStreamState();
 

--- a/src/convert-from-opencode-events.ts
+++ b/src/convert-from-opencode-events.ts
@@ -507,11 +507,16 @@ function handlePartDelta(
   state: StreamState,
 ): LanguageModelV3StreamPart[] {
   const parts: LanguageModelV3StreamPart[] = [];
-  const { partID, field, delta } = event.properties;
+  const { partID, messageID, field, delta } = event.properties;
 
   if (!delta) return parts;
 
-  // OpenCode sends both text and reasoning parts with field set as "text". 
+  const messageRole = state.messageRoles.get(messageID);
+  if (messageRole === "user") {
+    return parts;
+  }
+
+  // OpenCode sends both text and reasoning parts with field set as "text".
   // So we use the part ID tracked by prior message.part.updated events to differentiate.
   const isReasoning = field === "reasoning" || state.reasoningPartId === partID;
 


### PR DESCRIPTION
## Summary

- Cherry-picks and builds on the streaming fix from #9 by @abhijit-hota
- Adds `message.part.delta` event handling for true incremental text and reasoning streaming
- Applies user-role guard to `handlePartDelta` to prevent user prompt text from leaking into assistant stream output (matching existing `handlePartUpdated` filtering)
- Bumps `@opencode-ai/sdk` from `^1.1.65` to `^1.2.15`
- Bumps package version to `2.1.2` with CHANGELOG entry

## Context

PR #9 correctly identified that only `message.part.updated` events were handled, causing text to arrive in batches rather than streaming incrementally. During review, a missing user-message filter was identified in the new delta handler — this branch includes that fix along with the SDK version bump the contributor requested.

Closes #9

## Test plan

- [x] All 334 tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Regression test added for user-message delta filtering