### PR TITLE
pass message id to opencode via providerOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.1] - 2026-03-24
 
-- No changes yet.
+### Added
+
+- **User message ID passthrough** - Added support for `providerOptions.opencode.messageID` to control the user message ID sent to OpenCode. Must start with `"msg_"`. (PR [#14](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/pull/14) by [@abhijit-hota](https://github.com/abhijit-hota))
+- **Exported `OpencodeProviderOptions` type** - New type in `src/types.ts` documenting the per-request provider options surface.
+
+### Fixed
+
+- **Session creation error messages** - `Failed to create session` now includes the server error payload for easier debugging.
 
 ## [3.0.0] - 2026-03-17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "AI SDK v6 provider for OpenCode via @opencode-ai/sdk",
   "keywords": [
     "ai-sdk",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export type {
   OpencodeClient,
   OpencodeCreateClientOptions,
   OpencodeClientOptions,
+  OpencodeProviderOptions,
   OpencodeSettings,
   OpencodeProviderSettings,
   OpencodeProvider,

--- a/src/opencode-language-model.test.ts
+++ b/src/opencode-language-model.test.ts
@@ -294,6 +294,41 @@ describe("opencode-language-model", () => {
       );
     });
 
+    it("should pass providerOptions messageID to OpenCode", async () => {
+      await model.doGenerate({
+        prompt: basicPrompt,
+        providerOptions: {
+          opencode: {
+            messageID: "msg_user-123",
+          },
+        },
+      });
+
+      expect(mockClient.session.prompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageID: "msg_user-123",
+        }),
+      );
+    });
+
+    it("should reject providerOptions messageID without msg_ prefix", async () => {
+      await expect(
+        model.doGenerate({
+          prompt: basicPrompt,
+          providerOptions: {
+            opencode: {
+              messageID: "user-123",
+            },
+          },
+        }),
+      ).rejects.toThrow(
+        "providerOptions.opencode.messageID must start with 'msg_'",
+      );
+
+      expect(mockClient.session.create).not.toHaveBeenCalled();
+      expect(mockClient.session.prompt).not.toHaveBeenCalled();
+    });
+
     it("should include request body in response", async () => {
       const result = await model.doGenerate({
         prompt: basicPrompt,

--- a/src/opencode-language-model.ts
+++ b/src/opencode-language-model.ts
@@ -535,6 +535,9 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
     const format = this.getResponseFormat(options);
     const directory = this.getRequestDirectory();
 
+    // If provided, OpenCode will use this as the user message ID instead of generating one. Must start with "msg_".
+    const messageID = options.providerOptions?.opencode?.messageID as string | undefined;
+
     return {
       sessionID: sessionId,
       ...(directory ? { directory } : {}),
@@ -553,7 +556,7 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
         ? { system: systemPrompt ?? this.settings.systemPrompt }
         : {}),
       ...(this.settings.variant ? { variant: this.settings.variant } : {}),
-      ...(this.settings.messageID ? { messageID: this.settings.messageID } : {}),
+      ...(messageID ? { messageID } : {}),
       parts,
     };
   }

--- a/src/opencode-language-model.ts
+++ b/src/opencode-language-model.ts
@@ -9,6 +9,7 @@ import type {
   LanguageModelV3Usage,
   SharedV3Warning,
 } from "@ai-sdk/provider";
+import { InvalidArgumentError } from "@ai-sdk/provider";
 import type {
   Logger,
   OpencodeSettings,
@@ -81,6 +82,32 @@ function convertUsage(usage: StreamingUsage): LanguageModelV3Usage {
       total_cost: usage.totalCost,
     },
   };
+}
+
+function getMessageIDFromProviderOptions(
+  options: LanguageModelV3CallOptions,
+): string | undefined {
+  const messageID = options.providerOptions?.opencode?.messageID;
+
+  if (messageID == null) {
+    return undefined;
+  }
+
+  if (typeof messageID !== "string") {
+    throw new InvalidArgumentError({
+      argument: "providerOptions.opencode.messageID",
+      message: "providerOptions.opencode.messageID must be a string",
+    });
+  }
+
+  if (!messageID.startsWith("msg_")) {
+    throw new InvalidArgumentError({
+      argument: "providerOptions.opencode.messageID",
+      message: "providerOptions.opencode.messageID must start with 'msg_'",
+    });
+  }
+
+  return messageID;
 }
 
 function extractToolApprovalResponses(
@@ -202,6 +229,8 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
       warnings.push({ type: "other", message: warning });
     }
 
+    const messageID = getMessageIDFromProviderOptions(options);
+
     try {
       if (options.abortSignal?.aborted) {
         const error = new Error("Request aborted");
@@ -228,6 +257,7 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
         parts,
         systemPrompt,
         options,
+        messageID,
       );
 
       const result = await client.session.prompt(requestBody);
@@ -315,6 +345,8 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
     });
     warnings.push(...conversionWarnings);
 
+    const messageID = getMessageIDFromProviderOptions(options);
+
     const sessionId = await this.getOrCreateSession();
     const client = await this.clientManager.getClient();
 
@@ -323,6 +355,7 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
       parts,
       systemPrompt,
       options,
+      messageID,
     );
 
     const directory = this.getRequestDirectory();
@@ -531,12 +564,10 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
     >,
     systemPrompt: string | undefined,
     options: LanguageModelV3CallOptions,
+    messageID: string | undefined,
   ) {
     const format = this.getResponseFormat(options);
     const directory = this.getRequestDirectory();
-
-    // If provided, OpenCode will use this as the user message ID instead of generating one. Must start with "msg_".
-    const messageID = options.providerOptions?.opencode?.messageID as string | undefined;
 
     return {
       sessionID: sessionId,

--- a/src/opencode-language-model.ts
+++ b/src/opencode-language-model.ts
@@ -553,6 +553,7 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
         ? { system: systemPrompt ?? this.settings.systemPrompt }
         : {}),
       ...(this.settings.variant ? { variant: this.settings.variant } : {}),
+      ...(this.settings.messageID ? { messageID: this.settings.messageID } : {}),
       parts,
     };
   }
@@ -658,7 +659,9 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
 
       const data = result.data as { id: string } | undefined;
       if (!data?.id) {
-        throw new Error("Failed to create session");
+        throw new Error(
+          `Failed to create session: ${JSON.stringify(result.error ?? result.data)}`,
+        );
       }
 
       this.sessionId = data.id;

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,13 +68,6 @@ export interface OpencodeSettings {
   sessionId?: string;
 
   /**
-   * Message ID to use for the user message in OpenCode.
-   * If provided, OpenCode will use this instead of generating one.
-   * Must start with "msg_".
-   */
-  messageID?: string;
-
-  /**
    * Force creation of a new session, even if one already exists.
    * @default false
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,6 +248,17 @@ export interface ParsedModelId {
 }
 
 /**
+ * Per-request provider options for `providerOptions.opencode`.
+ */
+export interface OpencodeProviderOptions {
+  /**
+   * User message ID to send to OpenCode for this request.
+   * Must start with "msg_".
+   */
+  messageID?: string;
+}
+
+/**
  * Metadata returned in provider responses.
  */
 export interface OpencodeProviderMetadata {

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,13 @@ export interface OpencodeSettings {
   sessionId?: string;
 
   /**
+   * Message ID to use for the user message in OpenCode.
+   * If provided, OpenCode will use this instead of generating one.
+   * Must start with "msg_".
+   */
+  messageID?: string;
+
+  /**
    * Force creation of a new session, even if one already exists.
    * @default false
    */


### PR DESCRIPTION
We currently need to control the user message ID that is set in OpenCode. Passing it via `providerOptions` seemed appropriate:

```ts
const result = streamText({
	model: opencode("litellm/anthropic/claude-sonnet-4-6", {
		variant: "medium",
	}),
	providerOptions: {
		// We could use the same object for future prompt options if needed.
		opencode: { messageID: userMessageId } 
	},
	messages: await convertToModelMessages(processedMessages),
});
```

Is this okay or should I include it in the model config itself like the following?

```ts
const result = streamText({
	model: opencode("litellm/anthropic/claude-sonnet-4-6", {
		variant: "medium",
		lastUserMessageID: userMessageId
	}),
	messages: await convertToModelMessages(processedMessages),
});
```

P.S. Also changed the failed to create session log to be more verbose.
