### PR TITLE
feat: handle structured outputs properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2026-04-12
+
+### Added
+
+- **Structured output support** - OpenCode's `StructuredOutput` tool input is now re-emitted as text content so the AI SDK's `Output.object()` / `Output.array()` can parse `step.text` correctly. Previously this always threw `NoObjectGeneratedError`. (PR [#16](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/pull/16) by [@abhijit-hota](https://github.com/abhijit-hota))
+- **Exported `STRUCTURED_OUTPUT_TOOL` constant** - Shared constant for the `"StructuredOutput"` tool name.
+
 ## [3.0.1] - 2026-03-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "AI SDK v6 provider for OpenCode via @opencode-ai/sdk",
   "keywords": [
     "ai-sdk",

--- a/src/convert-from-opencode-events.test.ts
+++ b/src/convert-from-opencode-events.test.ts
@@ -1091,6 +1091,91 @@ describe("convert-from-opencode-events", () => {
         expect(state.textPartId).toBeUndefined();
       });
 
+      it("should emit {} for completed StructuredOutput with empty object output", () => {
+        const state = createStreamState();
+        const event: EventMessagePartUpdated = {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-1",
+              sessionID: "session-123",
+              messageID: "msg-1",
+              type: "tool",
+              callID: "call-so-1",
+              tool: "StructuredOutput",
+              state: {
+                status: "completed",
+                input: {},
+                output: "Structured output captured successfully.",
+                title: "Structured Output",
+                time: { start: 1000, end: 2000 },
+              },
+            } as ToolPart,
+          },
+        };
+
+        const parts = convertEventToStreamParts(event, state);
+
+        const delta = parts.find((p) => p.type === "text-delta") as { delta?: string } | undefined;
+        expect(delta).toBeDefined();
+        expect(delta!.delta).toBe("{}");
+      });
+
+      it("should close text part on StructuredOutput error", () => {
+        const state = createStreamState();
+
+        // First, get a text-start via a running event with real input
+        const runningEvent: EventMessagePartUpdated = {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-1",
+              sessionID: "session-123",
+              messageID: "msg-1",
+              type: "tool",
+              callID: "call-so-1",
+              tool: "StructuredOutput",
+              state: {
+                status: "running",
+                input: { output: "partial" },
+                time: { start: 1000 },
+              },
+            } as ToolPart,
+          },
+        };
+        convertEventToStreamParts(runningEvent, state);
+        expect(state.textStarted).toBe(true);
+
+        // Now error
+        const errorEvent: EventMessagePartUpdated = {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-1",
+              sessionID: "session-123",
+              messageID: "msg-1",
+              type: "tool",
+              callID: "call-so-1",
+              tool: "StructuredOutput",
+              state: {
+                status: "error",
+                input: { output: "partial" },
+                error: "Model did not produce structured output",
+                time: { start: 1000, end: 2000 },
+              },
+            } as ToolPart,
+          },
+        };
+
+        const parts = convertEventToStreamParts(errorEvent, state);
+
+        expect(parts).toEqual([
+          { type: "text-end", id: "structured-output-call-so-1" },
+        ]);
+        expect(state.textStarted).toBe(false);
+        expect(state.textPartId).toBeUndefined();
+      });
+
       it("should close prior text part when StructuredOutput starts", () => {
         const state = createStreamState();
         // Simulate an existing text part being open

--- a/src/convert-from-opencode-events.test.ts
+++ b/src/convert-from-opencode-events.test.ts
@@ -879,6 +879,254 @@ describe("convert-from-opencode-events", () => {
       });
     });
 
+    describe("StructuredOutput tool parts", () => {
+      it("should skip empty input during pending StructuredOutput", () => {
+        const state = createStreamState();
+        const event: EventMessagePartUpdated = {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-1",
+              sessionID: "session-123",
+              messageID: "msg-1",
+              type: "tool",
+              callID: "call-so-1",
+              tool: "StructuredOutput",
+              state: {
+                status: "pending",
+                input: {},
+                raw: '{}',
+              },
+            } as ToolPart,
+          },
+        };
+
+        const parts = convertEventToStreamParts(event, state);
+
+        expect(parts).toHaveLength(0);
+        expect(state.textStarted).toBe(false);
+      });
+
+      it("should emit text-start and text-delta for pending StructuredOutput with data", () => {
+        const state = createStreamState();
+        const event: EventMessagePartUpdated = {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-1",
+              sessionID: "session-123",
+              messageID: "msg-1",
+              type: "tool",
+              callID: "call-so-1",
+              tool: "StructuredOutput",
+              state: {
+                status: "pending",
+                input: { output: "partial", outputType: "markdown" },
+                raw: '{"output":"partial","outputType":"markdown"}',
+              },
+            } as ToolPart,
+          },
+        };
+
+        const parts = convertEventToStreamParts(event, state);
+
+        expect(parts[0]).toMatchObject({ type: "text-start", id: "structured-output-call-so-1" });
+        expect(parts[1]).toMatchObject({
+          type: "text-delta",
+          id: "structured-output-call-so-1",
+          delta: JSON.stringify({ output: "partial", outputType: "markdown" }),
+        });
+        expect(parts.some((p) => p.type === "tool-input-start")).toBe(false);
+      });
+
+      it("should emit incremental text-delta for running StructuredOutput", () => {
+        const state = createStreamState();
+
+        const makeEvent = (input: Record<string, unknown>): EventMessagePartUpdated => ({
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-1",
+              sessionID: "session-123",
+              messageID: "msg-1",
+              type: "tool",
+              callID: "call-so-1",
+              tool: "StructuredOutput",
+              state: {
+                status: "running",
+                input,
+                time: { start: 1000 },
+              },
+            } as ToolPart,
+          },
+        });
+
+        // First running event
+        const parts1 = convertEventToStreamParts(
+          makeEvent({ output: "hel" }),
+          state,
+        );
+        const deltas1 = parts1.filter((p) => p.type === "text-delta");
+        expect(deltas1).toHaveLength(1);
+        expect((deltas1[0] as any).delta).toBe(JSON.stringify({ output: "hel" }));
+
+        // Same input — no delta
+        const parts2 = convertEventToStreamParts(
+          makeEvent({ output: "hel" }),
+          state,
+        );
+        const deltas2 = parts2.filter((p) => p.type === "text-delta");
+        expect(deltas2).toHaveLength(0);
+
+        // Extended input — only the diff
+        const parts3 = convertEventToStreamParts(
+          makeEvent({ output: "hello world" }),
+          state,
+        );
+        const deltas3 = parts3.filter((p) => p.type === "text-delta");
+        expect(deltas3).toHaveLength(1);
+      });
+
+      it("should emit text-end on completed StructuredOutput", () => {
+        const state = createStreamState();
+        const structuredInput = { output: "# Result", outputType: "markdown" };
+
+        const event: EventMessagePartUpdated = {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-1",
+              sessionID: "session-123",
+              messageID: "msg-1",
+              type: "tool",
+              callID: "call-so-1",
+              tool: "StructuredOutput",
+              state: {
+                status: "completed",
+                input: structuredInput,
+                output: "Structured output captured successfully.",
+                title: "Structured Output",
+                time: { start: 1000, end: 2000 },
+              },
+            } as ToolPart,
+          },
+        };
+
+        const parts = convertEventToStreamParts(event, state);
+
+        expect(parts.some((p) => p.type === "text-start")).toBe(true);
+        expect(parts.some((p) => p.type === "text-delta")).toBe(true);
+        expect(parts.some((p) => p.type === "text-end")).toBe(true);
+
+        const delta = parts.find((p) => p.type === "text-delta") as { delta?: string } | undefined;
+        expect(JSON.parse(delta!.delta!)).toEqual(structuredInput);
+
+        // No tool-call or tool-result parts
+        expect(parts.some((p) => p.type === "tool-call")).toBe(false);
+        expect(parts.some((p) => p.type === "tool-result")).toBe(false);
+        expect(parts.some((p) => p.type === "tool-input-start")).toBe(false);
+      });
+
+      it("should stream text across pending → running → completed lifecycle", () => {
+        const state = createStreamState();
+        const callID = "call-so-lifecycle";
+
+        const makeEvent = (
+          status: string,
+          input: Record<string, unknown>,
+        ): EventMessagePartUpdated => ({
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-1",
+              sessionID: "session-123",
+              messageID: "msg-1",
+              type: "tool",
+              callID,
+              tool: "StructuredOutput",
+              state: {
+                status,
+                input,
+                ...(status === "pending" ? { raw: JSON.stringify(input) } : {}),
+                ...(status === "running" ? { time: { start: 1000 } } : {}),
+                ...(status === "completed"
+                  ? {
+                      output: "Structured output captured successfully.",
+                      title: "Structured Output",
+                      time: { start: 1000, end: 2000 },
+                    }
+                  : {}),
+              },
+            } as ToolPart,
+          },
+        });
+
+        // pending with empty input (real OpenCode behavior)
+        const parts0 = convertEventToStreamParts(
+          makeEvent("pending", {}),
+          state,
+        );
+        expect(parts0).toHaveLength(0);
+
+        // running with real input — text starts here
+        const parts1 = convertEventToStreamParts(
+          makeEvent("running", { output: "hello" }),
+          state,
+        );
+        expect(parts1[0]).toMatchObject({ type: "text-start" });
+        const deltas1 = parts1.filter((p) => p.type === "text-delta");
+        expect(deltas1).toHaveLength(1);
+        expect(JSON.parse((deltas1[0] as any).delta)).toEqual({ output: "hello" });
+
+        // completed with final input
+        const parts2 = convertEventToStreamParts(
+          makeEvent("completed", { output: "hello world", outputType: "markdown" }),
+          state,
+        );
+        expect(parts2.some((p) => p.type === "text-delta")).toBe(true);
+        expect(parts2.some((p) => p.type === "text-end")).toBe(true);
+
+        // State should be closed
+        expect(state.textStarted).toBe(false);
+        expect(state.textPartId).toBeUndefined();
+      });
+
+      it("should close prior text part when StructuredOutput starts", () => {
+        const state = createStreamState();
+        // Simulate an existing text part being open
+        state.textStarted = true;
+        state.textPartId = "existing-text-1";
+        state.lastTextContent = "some text";
+
+        const event: EventMessagePartUpdated = {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-1",
+              sessionID: "session-123",
+              messageID: "msg-1",
+              type: "tool",
+              callID: "call-so-1",
+              tool: "StructuredOutput",
+              state: {
+                status: "completed",
+                input: { result: "done" },
+                output: "ok",
+                title: "Structured Output",
+                time: { start: 1000, end: 2000 },
+              },
+            } as ToolPart,
+          },
+        };
+
+        const parts = convertEventToStreamParts(event, state);
+
+        // Should close the previous text part first
+        expect(parts[0]).toMatchObject({ type: "text-end", id: "existing-text-1" });
+        expect(parts[1]).toMatchObject({ type: "text-start", id: "structured-output-call-so-1" });
+      });
+    });
+
     describe("step-finish parts", () => {
       it("should accumulate usage from step-finish", () => {
         const state = createStreamState();

--- a/src/convert-from-opencode-events.ts
+++ b/src/convert-from-opencode-events.ts
@@ -12,6 +12,11 @@ import {
 } from "./opencode-part-utils.js";
 
 /**
+ * Tool name used by OpenCode to return structured output.
+ */
+export const STRUCTURED_OUTPUT_TOOL = "StructuredOutput" as const;
+
+/**
  * OpenCode event types (from SDK types.gen.ts).
  */
 export interface EventMessagePartUpdated {
@@ -633,7 +638,7 @@ function handleToolPart(
   // input. The AI SDK expects structured output as text content so that
   // `Output.object()` / `Output.array()` can parse it via `step.text`.
   // Emit the tool input as text stream parts instead of tool stream parts.
-  if (tool === "StructuredOutput") {
+  if (tool === STRUCTURED_OUTPUT_TOOL) {
     return handleStructuredOutputToolPart(callID, toolState, state, logger);
   }
 
@@ -850,7 +855,7 @@ function handleStructuredOutputToolPart(
   if (!streamState) {
     streamState = {
       callId: callID,
-      toolName: "StructuredOutput",
+      toolName: STRUCTURED_OUTPUT_TOOL,
       inputStarted: false,
       inputClosed: false,
       callEmitted: false,
@@ -878,7 +883,8 @@ function handleStructuredOutputToolPart(
     // OpenCode sends an empty {} input during early pending/running states
     // before the actual structured data is populated. Skip it — emitting it
     // would prepend a stray '{}' that breaks JSON parsing downstream.
-    if (inputStr === "{}") {
+    // Only skip for non-completed statuses; a completed {} is a valid output.
+    if (inputStr === "{}" && status !== "completed") {
       return;
     }
 
@@ -931,7 +937,13 @@ function handleStructuredOutputToolPart(
       }
       break;
 
-    // error: the StructuredOutputError finish reason will handle this
+    case "error":
+      if (state.textStarted && state.textPartId === textId) {
+        parts.push({ type: "text-end", id: textId });
+        state.textStarted = false;
+        state.textPartId = undefined;
+      }
+      break;
   }
 
   return parts;

--- a/src/convert-from-opencode-events.ts
+++ b/src/convert-from-opencode-events.ts
@@ -629,6 +629,14 @@ function handleToolPart(
   const parts: LanguageModelV3StreamPart[] = [];
   const { callID, tool, state: toolState } = part;
 
+  // OpenCode's StructuredOutput tool carries the structured JSON in its
+  // input. The AI SDK expects structured output as text content so that
+  // `Output.object()` / `Output.array()` can parse it via `step.text`.
+  // Emit the tool input as text stream parts instead of tool stream parts.
+  if (tool === "StructuredOutput") {
+    return handleStructuredOutputToolPart(callID, toolState, state, logger);
+  }
+
   let streamState = state.toolStates.get(callID);
   if (!streamState) {
     streamState = {
@@ -817,6 +825,113 @@ function handleToolPart(
         }
       }
       break;
+  }
+
+  return parts;
+}
+
+/**
+ * Handle a StructuredOutput tool part by converting it to text stream parts.
+ * The tool's input (the structured JSON) is streamed as text deltas so the
+ * AI SDK can parse partial output and build `step.text` for `Output.object()`.
+ */
+function handleStructuredOutputToolPart(
+  callID: string,
+  toolState: ToolState,
+  state: StreamState,
+  logger?: Logger | false,
+): LanguageModelV3StreamPart[] {
+  const parts: LanguageModelV3StreamPart[] = [];
+  const textId = `structured-output-${callID}`;
+
+  // We reuse the tool stream state map to track what we've already emitted,
+  // but only care about the text-related fields via the main StreamState.
+  let streamState = state.toolStates.get(callID);
+  if (!streamState) {
+    streamState = {
+      callId: callID,
+      toolName: "StructuredOutput",
+      inputStarted: false,
+      inputClosed: false,
+      callEmitted: false,
+      resultEmitted: false,
+      emittedAttachmentIds: new Set(),
+    };
+    state.toolStates.set(callID, streamState);
+  }
+
+  const emitTextDelta = (status: string, input: Record<string, unknown>) => {
+    const inputStr = safeStringifyToolInput(input, (message) => {
+      if (logger) {
+        logger.warn(
+          `Failed to serialize StructuredOutput input for ${callID}: ${message}`,
+        );
+      }
+    });
+
+    if (logger) {
+      logger.debug?.(
+        `[StructuredOutput stream] callID=${callID} status=${status} raw input=${JSON.stringify(input)} serialized=${inputStr} lastInput=${streamState!.lastInput ?? "(none)"}`,
+      );
+    }
+
+    // OpenCode sends an empty {} input during early pending/running states
+    // before the actual structured data is populated. Skip it — emitting it
+    // would prepend a stray '{}' that breaks JSON parsing downstream.
+    if (inputStr === "{}") {
+      return;
+    }
+
+    if (!state.textStarted || state.textPartId !== textId) {
+      if (state.textStarted && state.textPartId && state.textPartId !== textId) {
+        parts.push({ type: "text-end", id: state.textPartId });
+      }
+      parts.push({ type: "text-start", id: textId });
+      state.textStarted = true;
+      state.textPartId = textId;
+      state.lastTextContent = "";
+    }
+
+    if (!streamState!.lastInput) {
+      if (inputStr) {
+        parts.push({ type: "text-delta", id: textId, delta: inputStr });
+      }
+    } else if (inputStr.startsWith(streamState!.lastInput)) {
+      const delta = inputStr.slice(streamState!.lastInput.length);
+      if (delta) {
+        parts.push({ type: "text-delta", id: textId, delta });
+      }
+    } else if (inputStr) {
+      if (logger) {
+        logger.debug?.(
+          `[StructuredOutput stream] callID=${callID} non-prefix change detected, emitting full input. prev=${streamState!.lastInput} new=${inputStr}`,
+        );
+      }
+      parts.push({ type: "text-delta", id: textId, delta: inputStr });
+    }
+    streamState!.lastInput = inputStr;
+    state.lastTextContent = inputStr;
+  };
+
+  switch (toolState.status) {
+    case "pending":
+      emitTextDelta("pending", toolState.input);
+      break;
+
+    case "running":
+      emitTextDelta("running", toolState.input);
+      break;
+
+    case "completed":
+      emitTextDelta("completed", toolState.input);
+      if (state.textStarted && state.textPartId === textId) {
+        parts.push({ type: "text-end", id: textId });
+        state.textStarted = false;
+        state.textPartId = undefined;
+      }
+      break;
+
+    // error: the StructuredOutputError finish reason will handle this
   }
 
   return parts;

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ export {
   createStreamStartPart,
   isEventForSession,
   isSessionComplete,
+  STRUCTURED_OUTPUT_TOOL,
 } from "./convert-from-opencode-events.js";
 export type {
   OpencodeEvent,

--- a/src/opencode-language-model.test.ts
+++ b/src/opencode-language-model.test.ts
@@ -1152,6 +1152,43 @@ describe("opencode-language-model", () => {
       expect(JSON.parse((textParts[0] as { text: string }).text)).toEqual({ result: "done" });
     });
 
+    it("should not emit tool-call/tool-result for error-status StructuredOutput", async () => {
+      mockClient.session.prompt.mockResolvedValueOnce({
+        data: {
+          info: {
+            id: "msg-1",
+            sessionID: "session-123",
+            role: "assistant",
+            error: { name: "StructuredOutputError" },
+          },
+          parts: [
+            {
+              id: "part-1",
+              type: "tool",
+              callID: "call-so-1",
+              tool: "StructuredOutput",
+              state: {
+                status: "error",
+                input: {},
+                error: "Model did not produce structured output",
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await model.doGenerate({
+        prompt: [
+          { role: "user", content: [{ type: "text", text: "give me output" }] },
+        ],
+      });
+
+      const toolCalls = result.content.filter((c) => c.type === "tool-call");
+      const toolResults = result.content.filter((c) => c.type === "tool-result");
+      expect(toolCalls).toHaveLength(0);
+      expect(toolResults).toHaveLength(0);
+    });
+
     it("should safely stringify undefined tool input", async () => {
       mockClient.session.prompt.mockResolvedValueOnce({
         data: {

--- a/src/opencode-language-model.test.ts
+++ b/src/opencode-language-model.test.ts
@@ -538,6 +538,67 @@ describe("opencode-language-model", () => {
       expect(result.request?.body).toBeDefined();
     });
 
+    it("should emit StructuredOutput tool as text stream parts", async () => {
+      const structuredInput = { output: "# Hello", outputType: "markdown" };
+      mockClient.event.subscribe.mockResolvedValueOnce({
+        stream: (async function* () {
+          yield {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "part-1",
+                sessionID: "session-123",
+                messageID: "msg-1",
+                type: "tool",
+                callID: "call-so-1",
+                tool: "StructuredOutput",
+                state: {
+                  status: "completed",
+                  input: structuredInput,
+                  output: "Structured output captured successfully.",
+                  title: "Structured Output",
+                  time: { start: 1000, end: 2000 },
+                },
+              },
+            },
+          };
+          yield {
+            type: "session.status",
+            properties: {
+              sessionID: "session-123",
+              status: { type: "idle" },
+            },
+          };
+        })(),
+      });
+
+      const result = await model.doStream({
+        prompt: [
+          { role: "user", content: [{ type: "text", text: "give me output" }] },
+        ],
+      });
+
+      const parts: unknown[] = [];
+      const reader = result.stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        parts.push(value);
+      }
+
+      const textStart = parts.find((p: any) => p.type === "text-start");
+      const textDelta = parts.find((p: any) => p.type === "text-delta");
+      const textEnd = parts.find((p: any) => p.type === "text-end");
+      expect(textStart).toBeDefined();
+      expect(textDelta).toBeDefined();
+      expect(textEnd).toBeDefined();
+      expect(JSON.parse((textDelta as any).delta)).toEqual(structuredInput);
+
+      // No tool parts emitted
+      expect(parts.some((p: any) => p.type === "tool-call")).toBe(false);
+      expect(parts.some((p: any) => p.type === "tool-result")).toBe(false);
+    });
+
     it("should use native JSON schema mode without adding prompt instructions", async () => {
       const result = await model.doStream({
         prompt: basicPrompt,
@@ -984,6 +1045,111 @@ describe("opencode-language-model", () => {
         isError: true,
         result: "Command not found",
       });
+    });
+
+    it("should emit StructuredOutput tool input as text content", async () => {
+      const structuredInput = { output: "# Hello World", outputType: "markdown" };
+      mockClient.session.prompt.mockResolvedValueOnce({
+        data: {
+          info: {
+            id: "msg-1",
+            sessionID: "session-123",
+            role: "assistant",
+            finish: "end_turn",
+          },
+          parts: [
+            {
+              id: "part-1",
+              type: "tool",
+              callID: "call-so-1",
+              tool: "StructuredOutput",
+              state: {
+                status: "completed",
+                input: structuredInput,
+                output: "Structured output captured successfully.",
+              },
+            },
+            {
+              id: "part-2",
+              type: "step-finish",
+              reason: "end_turn",
+              cost: 0.001,
+              tokens: {
+                input: 10,
+                output: 5,
+                reasoning: 0,
+                cache: { read: 0, write: 0 },
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await model.doGenerate({
+        prompt: [
+          { role: "user", content: [{ type: "text", text: "give me output" }] },
+        ],
+      });
+
+      const textParts = result.content.filter((c) => c.type === "text");
+      expect(textParts).toHaveLength(1);
+      expect(JSON.parse((textParts[0] as { text: string }).text)).toEqual(structuredInput);
+
+      const toolCalls = result.content.filter((c) => c.type === "tool-call");
+      const toolResults = result.content.filter((c) => c.type === "tool-result");
+      expect(toolCalls).toHaveLength(0);
+      expect(toolResults).toHaveLength(0);
+    });
+
+    it("should not affect non-StructuredOutput tool parts", async () => {
+      mockClient.session.prompt.mockResolvedValueOnce({
+        data: {
+          info: {
+            id: "msg-1",
+            sessionID: "session-123",
+            role: "assistant",
+            finish: "tool_use",
+          },
+          parts: [
+            {
+              id: "part-1",
+              type: "tool",
+              callID: "call-1",
+              tool: "Bash",
+              state: {
+                status: "completed",
+                input: { command: "ls" },
+                output: "file.txt",
+              },
+            },
+            {
+              id: "part-2",
+              type: "tool",
+              callID: "call-so-1",
+              tool: "StructuredOutput",
+              state: {
+                status: "completed",
+                input: { result: "done" },
+                output: "Structured output captured successfully.",
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await model.doGenerate({
+        prompt: [
+          { role: "user", content: [{ type: "text", text: "do stuff" }] },
+        ],
+      });
+
+      const toolCalls = result.content.filter((c) => c.type === "tool-call");
+      expect(toolCalls).toHaveLength(1);
+      expect(toolCalls[0]).toMatchObject({ toolName: "Bash" });
+
+      const textParts = result.content.filter((c) => c.type === "text");
+      expect(textParts).toHaveLength(1);
+      expect(JSON.parse((textParts[0] as { text: string }).text)).toEqual({ result: "done" });
     });
 
     it("should safely stringify undefined tool input", async () => {

--- a/src/opencode-language-model.ts
+++ b/src/opencode-language-model.ts
@@ -25,6 +25,7 @@ import {
   createStreamStartPart,
   isEventForSession,
   isSessionComplete,
+  STRUCTURED_OUTPUT_TOOL,
   type Message,
   type Part,
 } from "./convert-from-opencode-events.js";
@@ -792,7 +793,7 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
       // input. The AI SDK expects structured output as text content so that
       // `Output.object()` / `Output.array()` can parse it via `step.text`.
       // Emit the tool input as a text part instead of tool-call/tool-result.
-      if (toolPart.tool === "StructuredOutput") {
+      if (toolPart.tool === STRUCTURED_OUTPUT_TOOL) {
         const serialized = safeStringifyToolInput(toolPart.state.input, (message) => {
           this.logger.warn(
             `Failed to serialize StructuredOutput input for ${toolPart.callID}: ${message}`,
@@ -833,6 +834,12 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
         }
       }
     } else if (toolPart.state.status === "error") {
+      // Don't emit tool-call/tool-result for StructuredOutput errors —
+      // the StructuredOutputError finish reason handles this.
+      if (toolPart.tool === STRUCTURED_OUTPUT_TOOL) {
+        return toolParts;
+      }
+
       toolParts.push({
         type: "tool-call",
         toolCallId: toolPart.callID,

--- a/src/opencode-language-model.ts
+++ b/src/opencode-language-model.ts
@@ -272,7 +272,13 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
         parts?: Part[];
       };
 
+      this.logger.debug?.(
+        `[doGenerate] raw parts from OpenCode: ${JSON.stringify(responseData.parts?.map(p => ({ type: p.type, ...(p.type === 'text' ? { text: (p as any).text?.slice(0, 200) } : {}), ...(p.type === 'tool' ? { tool: (p as any).tool, callID: (p as any).callID, status: (p as any).state?.status, input: (p as any).state?.input } : {}) })))}`,
+      );
       const content = this.extractContentFromParts(responseData.parts ?? []);
+      this.logger.debug?.(
+        `[doGenerate] extracted content: ${JSON.stringify(content.map(c => ({ type: c.type, ...(c.type === 'text' ? { text: (c as any).text?.slice(0, 200) } : {}), ...(c.type === 'tool-call' ? { toolName: (c as any).toolName } : {}) })))}`,
+      );
       const usage = this.extractUsageFromParts(responseData.parts ?? []);
       const finishReason = mapOpencodeFinishReason(responseData.info);
 
@@ -782,6 +788,23 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
     };
 
     if (toolPart.state.status === "completed") {
+      // OpenCode's StructuredOutput tool carries the structured JSON in its
+      // input. The AI SDK expects structured output as text content so that
+      // `Output.object()` / `Output.array()` can parse it via `step.text`.
+      // Emit the tool input as a text part instead of tool-call/tool-result.
+      if (toolPart.tool === "StructuredOutput") {
+        const serialized = safeStringifyToolInput(toolPart.state.input, (message) => {
+          this.logger.warn(
+            `Failed to serialize StructuredOutput input for ${toolPart.callID}: ${message}`,
+          );
+        });
+        this.logger.debug?.(
+          `[StructuredOutput doGenerate] callID=${toolPart.callID} status=${toolPart.state.status} raw input=${JSON.stringify(toolPart.state.input)} serialized=${serialized}`,
+        );
+        toolParts.push({ type: "text", text: serialized });
+        return toolParts;
+      }
+
       toolParts.push({
         type: "tool-call",
         toolCallId: toolPart.callID,


### PR DESCRIPTION
Hello, we are using `ai-sdk` to [generate structured data](https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data) with `Output.object()`:

```ts
const result = streamText({
  model: opencode("litellm/anthropic/claude-sonnet-4-6"),
  messages: await convertToModelMessages(userMessages),
  output: Output.object({
    schema: z.object({
      outputType: z.enum(["markdown", "plainText", "json", "error"]),
      output: z.string(),
    }),
  }),
});
```

But this always reseults in a `NoObjectGeneratedError`.

`ai-sdk` expects to find the structured JSON in `step.text`. If that's empty, it throws `NoObjectGeneratedError`.

OpenCode injects a `StructuredOutput` tool whose input schema matches the requested schema, sets `toolChoice: "required"`, and the model calls this tool with the structured data as the tool's input. The JSON lives in the tool call input.

This PR makes the provider emit text content instead of tool content when it sees a `StructuredOutput` tool part.