### PR TITLE
Fix zod 4 incompatibility in loggerSchema (closes #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2026-04-14
+
+### Fixed
+
+- **Zod 4 compatibility** - Replaced logger validation that depended on the removed `z.function().args().returns()` API so the package works across the declared `zod` v3/v4 peer range
+
 ## [0.0.2] - 2025-12-10
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-opencode-sdk",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "AI SDK v5 provider for OpenCode via @opencode-ai/sdk",
   "keywords": [
     "ai-sdk",

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -3,11 +3,23 @@ import type { OpencodeSettings, OpencodeProviderSettings, Logger } from './types
 
 /**
  * Schema for Logger interface.
+ *
+ * We use `z.custom<Fn>` with a runtime function check rather than
+ * `z.function()`. The signature for `z.function()` changed between zod 3 and
+ * zod 4 (`.args()`/`.returns()` were removed in favour of
+ * `z.function({ input, output })`), so using the plain function typeguard keeps
+ * the schema identical across both major versions — which matches this
+ * package's `"zod": "^3.0.0 || ^4.0.0"` peer range.
  */
+const loggerFn = z.custom<(message: string) => void>(
+  (val) => typeof val === 'function',
+  { message: 'Expected a function' }
+);
+
 const loggerSchema = z.object({
-  warn: z.function().args(z.string()).returns(z.void()),
-  error: z.function().args(z.string()).returns(z.void()),
-  debug: z.function().args(z.string()).returns(z.void()).optional(),
+  warn: loggerFn,
+  error: loggerFn,
+  debug: loggerFn.optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

Fixes #17: \`ai-sdk-v5\` tag line (\`v0.0.2\`) crashes at module-load under zod 4 because \`loggerSchema\` uses zod 3's \`z.function().args().returns()\` API, which was removed in zod 4.

## Changes

- \`src/validation.ts\`: Replace \`z.function()\`-based logger schemas with \`z.custom<Fn>(v => typeof v === 'function')\`. Identical behaviour across zod 3 and zod 4, matching the package's declared \`zod@^3 || ^4\` peer range.

## Why \`z.custom\` rather than \`z.function({ input, output })\`

\`z.function({ input, output })\` is zod 4 only and would break zod 3 consumers. \`z.custom\` is stable across both majors and captures exactly the runtime guarantee this schema needs — \"this value is a function\". The original \`.args(z.string())\` signature declaration was never actually validating call-sites anyway; it was documentation in type form, which the TypeScript \`Logger\` interface already provides.

## Testing

- \`npm run build\` — clean
- \`npx tsc --noEmit\` — clean
- \`npm test\` — 269 tests pass
- Verified module loads successfully under both \`zod@^3.24.0\` and \`zod@^4.1.0\`:
  \`\`\`bash
  npm install --no-save zod@^4.1.0 && node -e \"require('./dist/index.cjs').createOpencode({})\"
  # loaded OK
  \`\`\`

## Context

I hit this while integrating the provider into [claude-task-master#1685](https://github.com/eyaltoledano/claude-task-master/pull/1685). Task Master uses AI SDK v5 which pulls zod 4 through \`@ai-sdk/*\` packages, so any consumer in that ecosystem is affected.

## Test plan

- [x] Build passes
- [x] Typecheck clean
- [x] Existing vitest suite (269 tests) passes
- [x] Verified load under zod 3 and zod 4
- [ ] Maintainer review