### PR TITLE
Add regression tests for zod 3/4 logger schema + GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main, ai-sdk-v5]
+  pull_request:
+    branches: [main, ai-sdk-v5]
+
+jobs:
+  test:
+    name: Test (zod ${{ matrix.zod }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Exercise the full declared peer range to catch zod 3 / zod 4
+        # regressions early - see #17 for history.
+        zod: ['^3.24.0', '^4.1.0']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install zod ${{ matrix.zod }}
+        run: npm install --no-save zod@${{ matrix.zod }}
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npx eslint . --max-warnings=0
+        continue-on-error: true
+
+      - name: Build
+        run: npm run build
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Module loads under zod ${{ matrix.zod }}
+        run: node -e "require('./dist/index.cjs').createOpencode({})"

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -56,6 +56,89 @@ describe('validation', () => {
       validateSettings(settings, logger);
       expect(logger.warn).toHaveBeenCalled();
     });
+
+    describe('logger schema (zod 3/4 compatibility)', () => {
+      // Regression tests for https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/issues/17
+      // The loggerSchema was previously built with `z.function().args().returns()`
+      // which was removed in zod 4. These tests exercise the settings.logger
+      // validation path to ensure it works across both major zod versions.
+
+      it('should accept a valid logger with warn and error functions', () => {
+        const settings = {
+          logger: {
+            warn: vi.fn(),
+            error: vi.fn(),
+          },
+        };
+
+        const result = validateSettings(settings);
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should accept a valid logger with optional debug function', () => {
+        const settings = {
+          logger: {
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: vi.fn(),
+          },
+        };
+
+        const result = validateSettings(settings);
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should accept logger === false (disables logging)', () => {
+        const settings = {
+          logger: false as const,
+        };
+
+        const result = validateSettings(settings);
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should reject logger where warn is not a function', () => {
+        const settings = {
+          logger: {
+            warn: 'not a function',
+            error: vi.fn(),
+          },
+        } as unknown as Parameters<typeof validateSettings>[0];
+
+        const result = validateSettings(settings);
+        expect(
+          result.warnings.some((w) => w.includes('Settings validation'))
+        ).toBe(true);
+      });
+
+      it('should reject logger where error is missing', () => {
+        const settings = {
+          logger: {
+            warn: vi.fn(),
+          },
+        } as unknown as Parameters<typeof validateSettings>[0];
+
+        const result = validateSettings(settings);
+        expect(
+          result.warnings.some((w) => w.includes('Settings validation'))
+        ).toBe(true);
+      });
+
+      it('should validate nested logger under defaultSettings in provider schema', () => {
+        const providerSettings = {
+          hostname: 'localhost',
+          defaultSettings: {
+            logger: {
+              warn: vi.fn(),
+              error: vi.fn(),
+            },
+          },
+        };
+
+        const result = validateProviderSettings(providerSettings);
+        expect(result.warnings).toHaveLength(0);
+      });
+    });
   });
 
   describe('validateProviderSettings', () => {


### PR DESCRIPTION
## Summary

Follow-up to #18 (merged as v0.0.3). Two additions that didn't land in time:

1. **Regression tests** for the logger schema across zod 3 and zod 4, covering the code paths that were broken in #17.
2. **GitHub Actions CI workflow** - this repo has no CI today, so issues like #17 only surface at consumer install time.

## Changes

### \`src/validation.test.ts\` - 6 new tests

Exercise the \`settings.logger\` validation path (previously uncovered) to lock in zod 3/4 compatibility:

- Valid logger with \`warn\` + \`error\` accepted
- Valid logger with optional \`debug\` accepted
- \`logger: false\` (disable logging) accepted
- Logger with non-function \`warn\` rejected
- Logger with missing \`error\` rejected
- Nested logger under \`defaultSettings\` validated through the provider schema

### \`.github/workflows/ci.yml\`

Minimal CI workflow running on push/PR to \`main\` and \`ai-sdk-v5\`:

- Matrix tests against \`zod@^3.24.0\` and \`zod@^4.1.0\` (the declared peer range)
- Steps: \`npm ci\` → swap zod version → typecheck → lint (non-blocking) → build → vitest → import smoke test
- The final step (\`require('./dist/index.cjs').createOpencode({})\`) is specifically what would have caught #17

## Testing

- \`npm test\` - 275 tests pass (was 269 pre-#18, 269 + 6 new)
- Verified under zod 3 and zod 4 locally
- Workflow is self-contained; will activate on merge

## Risk

- None for the tests - pure additions
- CI workflow: no existing workflow to conflict with. Lint step is \`continue-on-error: true\` to avoid blocking on style issues I haven't audited.

## Test plan

- [x] Tests pass under zod 3
- [x] Tests pass under zod 4
- [x] Full suite (275 tests) green
- [ ] CI run on this PR validates the matrix