### PR TITLE
fix(lockfile): regenerate to restore strict npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main, ai-sdk-v5]
+  pull_request:
+    branches: [main, ai-sdk-v5]
+
+jobs:
+  test:
+    name: Test (zod ${{ matrix.zod }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Exercise the full declared peer range to catch zod 3 / zod 4
+        # regressions early - see #17 for history.
+        zod: ['^3.24.0', '^4.1.0']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install zod ${{ matrix.zod }}
+        run: npm install --no-save zod@${{ matrix.zod }}
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npx eslint . --max-warnings=0
+        continue-on-error: true
+
+      - name: Build
+        run: npm run build
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Module loads under zod ${{ matrix.zod }}
+        run: node -e "require('./dist/index.cjs').createOpencode({})"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4366,6 +4366,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite-node/node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/vite-node/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4396,6 +4408,15 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/vite-node/node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.2.7",

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -56,6 +56,89 @@ describe('validation', () => {
       validateSettings(settings, logger);
       expect(logger.warn).toHaveBeenCalled();
     });
+
+    describe('logger schema (zod 3/4 compatibility)', () => {
+      // Regression tests for https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/issues/17
+      // The loggerSchema was previously built with `z.function().args().returns()`
+      // which was removed in zod 4. These tests exercise the settings.logger
+      // validation path to ensure it works across both major zod versions.
+
+      it('should accept a valid logger with warn and error functions', () => {
+        const settings = {
+          logger: {
+            warn: vi.fn(),
+            error: vi.fn(),
+          },
+        };
+
+        const result = validateSettings(settings);
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should accept a valid logger with optional debug function', () => {
+        const settings = {
+          logger: {
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: vi.fn(),
+          },
+        };
+
+        const result = validateSettings(settings);
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should accept logger === false (disables logging)', () => {
+        const settings = {
+          logger: false as const,
+        };
+
+        const result = validateSettings(settings);
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should reject logger where warn is not a function', () => {
+        const settings = {
+          logger: {
+            warn: 'not a function',
+            error: vi.fn(),
+          },
+        } as unknown as Parameters<typeof validateSettings>[0];
+
+        const result = validateSettings(settings);
+        expect(
+          result.warnings.some((w) => w.includes('Settings validation'))
+        ).toBe(true);
+      });
+
+      it('should reject logger where error is missing', () => {
+        const settings = {
+          logger: {
+            warn: vi.fn(),
+          },
+        } as unknown as Parameters<typeof validateSettings>[0];
+
+        const result = validateSettings(settings);
+        expect(
+          result.warnings.some((w) => w.includes('Settings validation'))
+        ).toBe(true);
+      });
+
+      it('should validate nested logger under defaultSettings in provider schema', () => {
+        const providerSettings = {
+          hostname: 'localhost',
+          defaultSettings: {
+            logger: {
+              warn: vi.fn(),
+              error: vi.fn(),
+            },
+          },
+        };
+
+        const result = validateProviderSettings(providerSettings);
+        expect(result.warnings).toHaveLength(0);
+      });
+    });
   });
 
   describe('validateProviderSettings', () => {


### PR DESCRIPTION
## Problem

The CI workflow added in #19 fails on every push to \`ai-sdk-v5\` because \`package-lock.json\` is out-of-sync with \`package.json\`:

\`\`\`
npm error Missing: @types/node@25.6.0 from lock file
npm error Missing: undici-types@7.19.2 from lock file
\`\`\`

Failing run on the #19 merge commit: https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/actions/runs/24408770528

The drift was present before CI landed - it just wasn't visible without CI.

## Fix

Targeted lockfile update via \`npm install --package-lock-only\` to add the two missing transitive entries. 21-line addition, no other churn.

Chose this over loosening CI to \`npm install\` because:
- Strict \`npm ci\` guarantees reproducible installs and catches future drift
- Loosening CI just hides the same class of problem

## Test plan

- [x] \`npm ci\` succeeds locally on node 20 / npm 10.8.2
- [ ] CI passes on this PR (both zod 3 and zod 4 matrix jobs)