### PR TITLE
fix: buffer tool-approval-request until the tool call is registered (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.3] - 2026-06-09
+
+### Fixed
+
+- **Tool approval ordering** - Buffered OpenCode `permission.asked` events until the correlated tool call is registered, preventing AI SDK `ToolCallNotFoundForApprovalError` failures for provider-executed tools that require approval. Also treats early approval registration as closing the tool-input envelope so stale post-registration `running` updates cannot emit late `tool-input-delta` chunks. (Fixes [#22](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/issues/22), PR [#23](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/pull/23) by [@JulieLorin](https://github.com/JulieLorin))
+
 ## [3.0.2] - 2026-04-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "3.0.0",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-opencode-sdk",
-      "version": "3.0.0",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "AI SDK v6 provider for OpenCode via @opencode-ai/sdk",
   "keywords": [
     "ai-sdk",

--- a/src/convert-from-opencode-events.test.ts
+++ b/src/convert-from-opencode-events.test.ts
@@ -15,6 +15,7 @@ import {
   type ReasoningPart,
   type FilePart,
   type ToolPart,
+  type ToolState,
   type StepFinishPart,
   type EventMessagePartDelta,
 } from "./convert-from-opencode-events.js";
@@ -44,6 +45,7 @@ describe("convert-from-opencode-events", () => {
         messageRoles: expect.any(Map),
         permissionRequests: expect.any(Set),
         questionRequests: expect.any(Set),
+        pendingApprovals: expect.any(Map),
       });
     });
   });
@@ -544,10 +546,7 @@ describe("convert-from-opencode-events", () => {
 
         // 2. Delta arrives with field="text" for the reasoning part ID
         const reasoningDelta = makeDelta("reason-part", "text", "deep thought");
-        const reasoningParts = convertEventToStreamParts(
-          reasoningDelta,
-          state,
-        );
+        const reasoningParts = convertEventToStreamParts(reasoningDelta, state);
 
         // Should be reasoning-delta, not text-delta
         const deltaTypes = reasoningParts.map((p) => p.type);
@@ -895,7 +894,7 @@ describe("convert-from-opencode-events", () => {
               state: {
                 status: "pending",
                 input: {},
-                raw: '{}',
+                raw: "{}",
               },
             } as ToolPart,
           },
@@ -930,7 +929,10 @@ describe("convert-from-opencode-events", () => {
 
         const parts = convertEventToStreamParts(event, state);
 
-        expect(parts[0]).toMatchObject({ type: "text-start", id: "structured-output-call-so-1" });
+        expect(parts[0]).toMatchObject({
+          type: "text-start",
+          id: "structured-output-call-so-1",
+        });
         expect(parts[1]).toMatchObject({
           type: "text-delta",
           id: "structured-output-call-so-1",
@@ -942,7 +944,9 @@ describe("convert-from-opencode-events", () => {
       it("should emit incremental text-delta for running StructuredOutput", () => {
         const state = createStreamState();
 
-        const makeEvent = (input: Record<string, unknown>): EventMessagePartUpdated => ({
+        const makeEvent = (
+          input: Record<string, unknown>,
+        ): EventMessagePartUpdated => ({
           type: "message.part.updated",
           properties: {
             part: {
@@ -968,7 +972,9 @@ describe("convert-from-opencode-events", () => {
         );
         const deltas1 = parts1.filter((p) => p.type === "text-delta");
         expect(deltas1).toHaveLength(1);
-        expect((deltas1[0] as any).delta).toBe(JSON.stringify({ output: "hel" }));
+        expect((deltas1[0] as any).delta).toBe(
+          JSON.stringify({ output: "hel" }),
+        );
 
         // Same input — no delta
         const parts2 = convertEventToStreamParts(
@@ -1018,7 +1024,9 @@ describe("convert-from-opencode-events", () => {
         expect(parts.some((p) => p.type === "text-delta")).toBe(true);
         expect(parts.some((p) => p.type === "text-end")).toBe(true);
 
-        const delta = parts.find((p) => p.type === "text-delta") as { delta?: string } | undefined;
+        const delta = parts.find((p) => p.type === "text-delta") as
+          | { delta?: string }
+          | undefined;
         expect(JSON.parse(delta!.delta!)).toEqual(structuredInput);
 
         // No tool-call or tool-result parts
@@ -1076,11 +1084,16 @@ describe("convert-from-opencode-events", () => {
         expect(parts1[0]).toMatchObject({ type: "text-start" });
         const deltas1 = parts1.filter((p) => p.type === "text-delta");
         expect(deltas1).toHaveLength(1);
-        expect(JSON.parse((deltas1[0] as any).delta)).toEqual({ output: "hello" });
+        expect(JSON.parse((deltas1[0] as any).delta)).toEqual({
+          output: "hello",
+        });
 
         // completed with final input
         const parts2 = convertEventToStreamParts(
-          makeEvent("completed", { output: "hello world", outputType: "markdown" }),
+          makeEvent("completed", {
+            output: "hello world",
+            outputType: "markdown",
+          }),
           state,
         );
         expect(parts2.some((p) => p.type === "text-delta")).toBe(true);
@@ -1116,7 +1129,9 @@ describe("convert-from-opencode-events", () => {
 
         const parts = convertEventToStreamParts(event, state);
 
-        const delta = parts.find((p) => p.type === "text-delta") as { delta?: string } | undefined;
+        const delta = parts.find((p) => p.type === "text-delta") as
+          | { delta?: string }
+          | undefined;
         expect(delta).toBeDefined();
         expect(delta!.delta).toBe("{}");
       });
@@ -1207,8 +1222,14 @@ describe("convert-from-opencode-events", () => {
         const parts = convertEventToStreamParts(event, state);
 
         // Should close the previous text part first
-        expect(parts[0]).toMatchObject({ type: "text-end", id: "existing-text-1" });
-        expect(parts[1]).toMatchObject({ type: "text-start", id: "structured-output-call-so-1" });
+        expect(parts[0]).toMatchObject({
+          type: "text-end",
+          id: "existing-text-1",
+        });
+        expect(parts[1]).toMatchObject({
+          type: "text-start",
+          id: "structured-output-call-so-1",
+        });
       });
     });
 
@@ -1345,28 +1366,161 @@ describe("convert-from-opencode-events", () => {
     });
 
     describe("permission events", () => {
-      it("should emit tool-approval-request for permission.asked", () => {
-        const state = createStreamState();
-        const event: EventPermissionAsked = {
-          type: "permission.asked",
-          properties: {
-            id: "approval-1",
+      const permissionAsked = (
+        overrides: Partial<EventPermissionAsked["properties"]> = {},
+      ): EventPermissionAsked => ({
+        type: "permission.asked",
+        properties: {
+          id: "approval-1",
+          sessionID: "session-123",
+          permission: "bash",
+          patterns: ["npm test"],
+          tool: { messageID: "msg-1", callID: "call-1" },
+          ...overrides,
+        },
+      });
+
+      const toolEvent = (
+        status: ToolState["status"],
+        extra: Record<string, unknown> = {},
+      ): EventMessagePartUpdated => ({
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "part-1",
             sessionID: "session-123",
+            messageID: "msg-1",
+            type: "tool",
+            callID: "call-1",
+            tool: "bash",
+            state: {
+              status,
+              input: { command: "ls" },
+              ...extra,
+            },
+          } as ToolPart,
+        },
+      });
+
+      const expectedApproval = {
+        type: "tool-approval-request",
+        approvalId: "approval-1",
+        toolCallId: "call-1",
+        providerMetadata: {
+          opencode: {
+            sessionId: "session-123",
             permission: "bash",
             patterns: ["npm test"],
-            tool: {
-              messageID: "msg-1",
-              callID: "call-1",
-            },
           },
-        };
+        },
+      };
 
-        const parts = convertEventToStreamParts(event, state);
+      // Case A (the bug, issue #22): permission.asked arrives before the tool
+      // call has been registered. It must be buffered, not emitted early, and
+      // flushed only after the tool call reaches tool-input-available.
+      it("buffers permission.asked until the tool call is registered, then flushes after tool-call", () => {
+        const state = createStreamState();
+
+        // Tool starts (pending) -> tool-input-start only.
+        const startParts = convertEventToStreamParts(
+          toolEvent("pending"),
+          state,
+        );
+        expect(startParts.map((p) => p.type)).toEqual(["tool-input-start"]);
+
+        // permission.asked arrives next -> buffered, nothing emitted, no error.
+        const askedParts = convertEventToStreamParts(permissionAsked(), state);
+        expect(askedParts).toEqual([]);
+        expect(state.pendingApprovals.has("call-1")).toBe(true);
+
+        // Input becomes available (running) -> tool-call is registered and the
+        // approval is flushed immediately after it.
+        const runningParts = convertEventToStreamParts(
+          toolEvent("running", { time: { start: 1000 } }),
+          state,
+        );
+        const types = runningParts.map((p) => p.type);
+        const callIdx = types.indexOf("tool-call");
+        const approvalIdx = types.indexOf("tool-approval-request");
+        expect(callIdx).toBeGreaterThanOrEqual(0);
+        expect(approvalIdx).toBeGreaterThan(callIdx);
+        expect(runningParts[approvalIdx]).toEqual(expectedApproval);
+        expect(state.pendingApprovals.has("call-1")).toBe(false);
+      });
+
+      it("never emits the approval before the tool call is registered", () => {
+        const state = createStreamState();
+        convertEventToStreamParts(toolEvent("pending"), state);
+        const askedParts = convertEventToStreamParts(permissionAsked(), state);
+        expect(askedParts.some((p) => p.type === "tool-approval-request")).toBe(
+          false,
+        );
+        expect(askedParts.some((p) => p.type === "error")).toBe(false);
+      });
+
+      // Case B (no regression): permission.asked arrives after the tool call is
+      // already registered -> emitted immediately.
+      it("emits the approval immediately when the tool call is already registered", () => {
+        const state = createStreamState();
+        convertEventToStreamParts(
+          toolEvent("completed", {
+            output: "file1\nfile2",
+            title: "List files",
+            time: { start: 1000, end: 2000 },
+          }),
+          state,
+        );
+        const tool = state.toolStates.get("call-1");
+        expect(tool?.callEmitted).toBe(true);
+
+        const askedParts = convertEventToStreamParts(permissionAsked(), state);
+        expect(askedParts).toEqual([expectedApproval]);
+      });
+
+      // Case C (criterion 4): a tool that errors with an approval still buffered
+      // yields a terminal denied result and leaves no dangling approval.
+      it("drops a buffered approval and emits a terminal error result on tool error", () => {
+        const state = createStreamState();
+        const logger: Logger = { warn: vi.fn(), error: vi.fn() };
+
+        convertEventToStreamParts(toolEvent("pending"), state);
+        convertEventToStreamParts(permissionAsked(), state);
+        expect(state.pendingApprovals.has("call-1")).toBe(true);
+
+        const errorParts = convertEventToStreamParts(
+          toolEvent("error", {
+            error: "Permission denied",
+            time: { start: 1000, end: 2000 },
+          }),
+          state,
+          logger,
+        );
+
+        expect(errorParts.some((p) => p.type === "tool-approval-request")).toBe(
+          false,
+        );
+        const result = errorParts.find((p) => p.type === "tool-result");
+        expect(result).toMatchObject({
+          toolCallId: "call-1",
+          result: "Permission denied",
+          isError: true,
+        });
+        expect(state.pendingApprovals.has("call-1")).toBe(false);
+      });
+
+      // Fallback: permission.asked with no tool.callID can't be correlated, so
+      // it is emitted immediately (legacy behavior).
+      it("emits immediately when permission.asked has no tool callID", () => {
+        const state = createStreamState();
+        const parts = convertEventToStreamParts(
+          permissionAsked({ tool: undefined }),
+          state,
+        );
         expect(parts).toEqual([
           {
             type: "tool-approval-request",
             approvalId: "approval-1",
-            toolCallId: "call-1",
+            toolCallId: "approval-1",
             providerMetadata: {
               opencode: {
                 sessionId: "session-123",
@@ -1376,6 +1530,29 @@ describe("convert-from-opencode-events", () => {
             },
           },
         ]);
+      });
+
+      it("emits a buffered approval only once (dedupe)", () => {
+        const state = createStreamState();
+        convertEventToStreamParts(toolEvent("pending"), state);
+        convertEventToStreamParts(permissionAsked(), state);
+        // Duplicate permission.asked while still buffered.
+        convertEventToStreamParts(permissionAsked(), state);
+
+        const runningParts = convertEventToStreamParts(
+          toolEvent("running", { time: { start: 1000 } }),
+          state,
+        );
+        const approvals = runningParts.filter(
+          (p) => p.type === "tool-approval-request",
+        );
+        expect(approvals).toHaveLength(1);
+
+        // A late duplicate after registration must not re-emit.
+        const lateParts = convertEventToStreamParts(permissionAsked(), state);
+        expect(lateParts.some((p) => p.type === "tool-approval-request")).toBe(
+          false,
+        );
       });
     });
 

--- a/src/convert-from-opencode-events.test.ts
+++ b/src/convert-from-opencode-events.test.ts
@@ -1508,6 +1508,76 @@ describe("convert-from-opencode-events", () => {
         expect(state.pendingApprovals.has("call-1")).toBe(false);
       });
 
+      // Once the tool call is registered for approval, its input envelope is
+      // closed: a later `running` event must not emit a stale tool-input-delta
+      // (which would strand the UI tool part in `input-streaming`).
+      it("does not emit a tool-input-delta after the tool call is registered early", () => {
+        const state = createStreamState();
+        const logger: Logger = { warn: vi.fn(), error: vi.fn() };
+
+        // running input A -> input-start + delta.
+        convertEventToStreamParts(
+          toolEvent("running", {
+            input: { command: "ls" },
+            time: { start: 1000 },
+          }),
+          state,
+          logger,
+        );
+
+        // permission.asked closes the envelope: input-end + tool-call + approval.
+        const askedParts = convertEventToStreamParts(
+          permissionAsked(),
+          state,
+          logger,
+        );
+        expect(askedParts.map((p) => p.type)).toEqual([
+          "tool-input-end",
+          "tool-call",
+          "tool-approval-request",
+        ]);
+
+        // running input B (changed) -> no late delta; the change is warned, not applied.
+        const run2 = convertEventToStreamParts(
+          toolEvent("running", {
+            input: { command: "ls -la" },
+            time: { start: 1000 },
+          }),
+          state,
+          logger,
+        );
+        expect(run2.some((p) => p.type === "tool-input-delta")).toBe(false);
+        expect(run2).toEqual([]);
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining("after the tool call"),
+        );
+        // The exposed input stays bound to what the approval was requested for.
+        expect(state.toolStates.get("call-1")?.lastInput).toBe(
+          '{"command":"ls"}',
+        );
+      });
+
+      it("ignores a repeated running event with unchanged input after registration", () => {
+        const state = createStreamState();
+        const logger: Logger = { warn: vi.fn(), error: vi.fn() };
+
+        convertEventToStreamParts(
+          toolEvent("running", { time: { start: 1000 } }),
+          state,
+          logger,
+        );
+        convertEventToStreamParts(permissionAsked(), state, logger);
+
+        // Same input again -> nothing emitted, no warning.
+        const run2 = convertEventToStreamParts(
+          toolEvent("running", { time: { start: 1000 } }),
+          state,
+          logger,
+        );
+        expect(run2).toEqual([]);
+        expect(logger.warn).not.toHaveBeenCalled();
+      });
+
       // Fallback: permission.asked with no tool.callID can't be correlated, so
       // it is emitted immediately (legacy behavior).
       it("emits immediately when permission.asked has no tool callID", () => {

--- a/src/convert-from-opencode-events.ts
+++ b/src/convert-from-opencode-events.ts
@@ -233,6 +233,21 @@ export interface Message {
 }
 
 /**
+ * A buffered tool-approval-request, held until its tool call has been
+ * registered in the stream (see issue #22). Correlates an OpenCode
+ * `permission.asked` event to the tool call it gates.
+ */
+export interface PendingApproval {
+  approvalId: string;
+  toolCallId: string;
+  toolName: string;
+  providerExecuted: boolean;
+  permission: string;
+  patterns: string[];
+  sessionId: string;
+}
+
+/**
  * State for tracking streaming progress.
  */
 export interface StreamState {
@@ -247,6 +262,12 @@ export interface StreamState {
   messageRoles: Map<string, "user" | "assistant">;
   permissionRequests: Set<string>;
   questionRequests: Set<string>;
+  /**
+   * Tool-approval-requests buffered (keyed by tool callID) until the
+   * correlated tool call has been registered. Flushed the instant the
+   * tool call reaches `tool-input-available`.
+   */
+  pendingApprovals: Map<string, PendingApproval>;
 }
 
 /**
@@ -272,7 +293,88 @@ export function createStreamState(): StreamState {
     messageRoles: new Map(),
     permissionRequests: new Set(),
     questionRequests: new Set(),
+    pendingApprovals: new Map(),
   };
+}
+
+/**
+ * Emit the stream parts that register a tool call (`tool-input-start` →
+ * `tool-input-end` → `tool-call`), bringing it to `tool-input-available`.
+ * Idempotent: each part is emitted at most once per call, driven by the
+ * flags on `streamState`. Used both by the terminal (completed/error) paths
+ * and to register a call early when an approval is pending for it.
+ */
+function registerToolCall(
+  callID: string,
+  toolName: string,
+  inputStr: string,
+  streamState: ToolStreamState,
+  parts: LanguageModelV3StreamPart[],
+): void {
+  if (!streamState.inputStarted) {
+    parts.push({
+      type: "tool-input-start",
+      id: callID,
+      toolName,
+      providerExecuted: true,
+      dynamic: true,
+    });
+    streamState.inputStarted = true;
+  }
+
+  if (!streamState.inputClosed) {
+    parts.push({ type: "tool-input-end", id: callID });
+    streamState.inputClosed = true;
+  }
+
+  if (!streamState.callEmitted) {
+    parts.push({
+      type: "tool-call",
+      toolCallId: callID,
+      toolName,
+      input: inputStr,
+      providerExecuted: true,
+      dynamic: true,
+    });
+    streamState.callEmitted = true;
+  }
+}
+
+/**
+ * Emit a buffered `tool-approval-request` for the given tool call, if one is
+ * pending and has not already been emitted. The approval must only be flushed
+ * after the tool call has been registered (issue #22), so callers are
+ * responsible for ensuring `tool-input-available` precedes this.
+ */
+function flushPendingApproval(
+  callID: string,
+  state: StreamState,
+  parts: LanguageModelV3StreamPart[],
+): void {
+  const pending = state.pendingApprovals.get(callID);
+  if (!pending) {
+    return;
+  }
+
+  state.pendingApprovals.delete(callID);
+
+  if (state.permissionRequests.has(pending.approvalId)) {
+    return;
+  }
+  state.permissionRequests.add(pending.approvalId);
+
+  parts.push({
+    type: "tool-approval-request",
+    approvalId: pending.approvalId,
+    toolCallId: pending.toolCallId,
+    providerMetadata: {
+      opencode: {
+        sessionId: pending.sessionId,
+        permission: pending.permission,
+        patterns: pending.patterns,
+      },
+    },
+  });
 }
 
 /**
@@ -373,22 +475,51 @@ export function convertEventToStreamParts(
     case "permission.asked": {
       const permissionEvent = event as EventPermissionAsked;
       const requestId = permissionEvent.properties.id;
+      const callID = permissionEvent.properties.tool?.callID;
 
-      if (!state.permissionRequests.has(requestId)) {
-        state.permissionRequests.add(requestId);
-        parts.push({
-          type: "tool-approval-request",
-          approvalId: requestId,
-          toolCallId: permissionEvent.properties.tool?.callID ?? requestId,
-          providerMetadata: {
-            opencode: {
-              sessionId: permissionEvent.properties.sessionID,
-              permission: permissionEvent.properties.permission,
-              patterns: permissionEvent.properties.patterns,
-            },
-          },
-        });
+      // Already emitted (e.g. a duplicate event) — ignore.
+      if (state.permissionRequests.has(requestId)) {
+        break;
       }
+
+      const toolState = callID ? state.toolStates.get(callID) : undefined;
+      const bufferKey = callID ?? requestId;
+      const record: PendingApproval = {
+        approvalId: requestId,
+        toolCallId: callID ?? requestId,
+        toolName: toolState?.toolName ?? "",
+        providerExecuted: true,
+        permission: permissionEvent.properties.permission,
+        patterns: permissionEvent.properties.patterns,
+        sessionId: permissionEvent.properties.sessionID,
+      };
+      state.pendingApprovals.set(bufferKey, record);
+
+      if (!callID) {
+        // No tool correlation available — preserve the legacy behavior and
+        // emit immediately (nothing to register against).
+        flushPendingApproval(bufferKey, state, parts);
+        break;
+      }
+
+      if (toolState?.callEmitted) {
+        // The tool call is already registered — safe to emit now.
+        flushPendingApproval(callID, state, parts);
+      } else if (toolState && toolState.lastInput !== undefined) {
+        // Input has streamed (a `running` event was seen) but the tool call
+        // hasn't been finalized yet. Register it early, then flush so the
+        // approval lands after `tool-input-available` (issue #22).
+        registerToolCall(
+          callID,
+          toolState.toolName,
+          toolState.lastInput,
+          toolState,
+          parts,
+        );
+        flushPendingApproval(callID, state, parts);
+      }
+      // Otherwise the tool call isn't ready: keep the approval buffered and
+      // flush it from handleToolPart once the call is registered.
       break;
     }
 
@@ -543,7 +674,11 @@ function handlePartDelta(
     state.lastReasoningContent += delta;
   } else {
     if (!state.textStarted || state.textPartId !== partID) {
-      if (state.textStarted && state.textPartId && state.textPartId !== partID) {
+      if (
+        state.textStarted &&
+        state.textPartId &&
+        state.textPartId !== partID
+      ) {
         parts.push({ type: "text-end", id: state.textPartId });
       }
       parts.push({ type: "text-start", id: partID });
@@ -716,42 +851,30 @@ function handleToolPart(
         });
       }
       streamState.lastInput = inputStr;
+
+      // If an approval is buffered for this call, the input is now available:
+      // register the tool call and flush the approval so it lands after
+      // `tool-input-available`, before the tool executes (issue #22).
+      if (state.pendingApprovals.has(callID) && !streamState.callEmitted) {
+        registerToolCall(callID, tool, inputStr, streamState, parts);
+        flushPendingApproval(callID, state, parts);
+      }
       break;
     }
 
-    case "completed":
-      if (!streamState.inputClosed) {
-        if (!streamState.inputStarted) {
-          parts.push({
-            type: "tool-input-start",
-            id: callID,
-            toolName: tool,
-            providerExecuted: true,
-            dynamic: true,
-          });
-          streamState.inputStarted = true;
+    case "completed": {
+      const inputStr = safeStringifyToolInput(toolState.input, (message) => {
+        if (logger) {
+          logger.warn(
+            `Failed to serialize tool input for ${callID}: ${message}`,
+          );
         }
-        parts.push({ type: "tool-input-end", id: callID });
-        streamState.inputClosed = true;
-      }
+      });
+      registerToolCall(callID, tool, inputStr, streamState, parts);
 
-      if (!streamState.callEmitted) {
-        parts.push({
-          type: "tool-call",
-          toolCallId: callID,
-          toolName: tool,
-          input: safeStringifyToolInput(toolState.input, (message) => {
-            if (logger) {
-              logger.warn(
-                `Failed to serialize tool input for ${callID}: ${message}`,
-              );
-            }
-          }),
-          providerExecuted: true,
-          dynamic: true,
-        });
-        streamState.callEmitted = true;
-      }
+      // Flush any approval still buffered for this call before the terminal
+      // result, so it never trails `tool-output-available`.
+      flushPendingApproval(callID, state, parts);
 
       if (!streamState.resultEmitted) {
         parts.push({
@@ -778,40 +901,22 @@ function handleToolPart(
         }
       }
       break;
+    }
 
-    case "error":
-      if (!streamState.inputClosed) {
-        if (!streamState.inputStarted) {
-          parts.push({
-            type: "tool-input-start",
-            id: callID,
-            toolName: tool,
-            providerExecuted: true,
-            dynamic: true,
-          });
-          streamState.inputStarted = true;
+    case "error": {
+      const inputStr = safeStringifyToolInput(toolState.input, (message) => {
+        if (logger) {
+          logger.warn(
+            `Failed to serialize tool input for ${callID}: ${message}`,
+          );
         }
-        parts.push({ type: "tool-input-end", id: callID });
-        streamState.inputClosed = true;
-      }
+      });
+      registerToolCall(callID, tool, inputStr, streamState, parts);
 
-      if (!streamState.callEmitted) {
-        parts.push({
-          type: "tool-call",
-          toolCallId: callID,
-          toolName: tool,
-          input: safeStringifyToolInput(toolState.input, (message) => {
-            if (logger) {
-              logger.warn(
-                `Failed to serialize tool input for ${callID}: ${message}`,
-              );
-            }
-          }),
-          providerExecuted: true,
-          dynamic: true,
-        });
-        streamState.callEmitted = true;
-      }
+      // The tool failed (e.g. a rejected permission): drop any buffered
+      // approval so it never dangles. The terminal error result below is the
+      // final word for this call (issue #22, criterion 4).
+      state.pendingApprovals.delete(callID);
 
       if (!streamState.resultEmitted) {
         parts.push({
@@ -830,6 +935,7 @@ function handleToolPart(
         }
       }
       break;
+    }
   }
 
   return parts;
@@ -889,7 +995,11 @@ function handleStructuredOutputToolPart(
     }
 
     if (!state.textStarted || state.textPartId !== textId) {
-      if (state.textStarted && state.textPartId && state.textPartId !== textId) {
+      if (
+        state.textStarted &&
+        state.textPartId &&
+        state.textPartId !== textId
+      ) {
         parts.push({ type: "text-end", id: state.textPartId });
       }
       parts.push({ type: "text-start", id: textId });

--- a/src/convert-from-opencode-events.ts
+++ b/src/convert-from-opencode-events.ts
@@ -825,6 +825,23 @@ function handleToolPart(
           );
         }
       });
+
+      // Once the tool call has been registered (e.g. an approval closed the
+      // input envelope early, issue #22), the exposed input is immutable. Never
+      // emit a late `tool-input-delta` after `tool-input-available` — that would
+      // leave the UI tool part stuck in `input-streaming` while carrying an
+      // approval. A later `running` event with the same input is ignored; a
+      // changed input is surfaced as a warning rather than silently mutated.
+      if (streamState.callEmitted) {
+        if (inputStr !== streamState.lastInput && logger) {
+          logger.warn(
+            `Ignoring tool input change for ${callID} after the tool call ` +
+              `was registered; the input exposed for approval is immutable.`,
+          );
+        }
+        break;
+      }
+
       if (!streamState.lastInput) {
         if (inputStr) {
           parts.push({


### PR DESCRIPTION
## Summary

Fixes #22 — provider-executed tools with `"ask"` permission can't use the AI SDK's native tool-approval flow because the `tool-approval-request` is emitted **before** the tool call is registered in the stream, so `streamText` throws `ToolCallNotFoundForApprovalError` and aborts the turn.

This enforces the invariant from the issue: **a `tool-approval-request` is only emitted after the correlated tool call has reached `tool-input-available`.**

## The bug

A single `bash` call (permission `"ask"`) streamed in this order (provider v3.0.2, `ai@6`):

```
tool-input-start   (toolName: bash, providerExecuted: true, dynamic: true)
error              ("Tool call toolu_… not found for approval request per_…")
tool-input-delta   ({"command":"ls …"})
```

OpenCode's `permission.asked` was mapped to a `tool-approval-request` immediately, landing between `tool-input-start` and the tool call's registration. The AI SDK can't correlate it, so `addToolApprovalResponse` / `sendAutomaticallyWhen` are unusable and apps must reply to OpenCode's permission endpoint out-of-band.

## The fix

- Add a `pendingApprovals` buffer (keyed by tool `callID`) to the stream state — the small correlation record @rpelevin proposed.
- On `permission.asked`:
  - **no `callID`** → emit immediately (legacy behavior, nothing to correlate against);
  - **tool call already registered** (`callEmitted`) → emit immediately (no regression);
  - **otherwise** → buffer, and flush the instant the tool call is registered.
- **Early registration:** an `"ask"` tool blocks *before* it completes, but the existing `tool-call` part is only emitted at status `completed`/`error` — too late to ever flush in time. So when an approval is buffered and the tool's input becomes available (the `running` event), the tool call is registered early (`tool-input-end` → `tool-call`) and the approval is flushed right after — surfacing it **before** execution, which is the order the native round-trip needs.
- A tool that errors drops any still-buffered approval, so a rejection yields a terminal denied result and never leaves a dangling approval.

Guaranteed order for a gated call:
`tool-input-start → tool-input-delta → tool-input-end → tool-call → tool-approval-request → (tool-result)`

## Tests

New `permission events` suite in `convert-from-opencode-events.test.ts` covering @rpelevin's acceptance cases:

1. `permission.asked` between `tool-input-start` and input-available → **buffered**, no early emit, no error.
2. Approval emitted only **after** the tool call is registered, referencing the same `toolCallId` + `approvalId`.
3. Approval emitted immediately when the tool call is already registered (no regression).
4. Tool error with a buffered approval → terminal `isError` result, no dangling approval.
5. No-`callID` fallback emits immediately; duplicate `permission.asked` dedupes to a single request.

`npm run ci` (typecheck + lint + test) is green — 354 tests pass.

## Scope / follow-up

This change is contained to the event converter and its unit tests. Fully exercising the end-to-end live round-trip (the turn must finish while OpenCode holds the tool open, then resume on reply) needs a live OpenCode server and is left as a follow-up; the converter now emits parts in the order the AI SDK requires.

## Credit

Buffering design and acceptance tests proposed by @rpelevin in #22.
