### PR TITLE
fix: clarify empty OpenCode response errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Empty OpenCode response errors** - Empty-body JSON parse failures from the OpenCode server (`SyntaxError: Unexpected end of JSON input`, most commonly caused by an invalid or unavailable `provider/model` ID) are now wrapped in an actionable `APICallError` that names the requested model ID and likely cause. The same wrapping is applied to the streaming prompt failure path, and `modelId` is now included in API call error metadata. (Fixes [#21](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/issues/21), PR [#24](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/pull/24) by [@slegarraga](https://github.com/slegarraga))
+- **image-input example** - Updated `examples/image-input.ts` to use `openai/gpt-5.5` instead of the no-longer-available `openai/gpt-5.3-codex`, which caused the example to fail silently (empty response, zero usage).
 
 ## [3.0.3] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.4] - 2026-06-11
+
+### Fixed
+
+- **Empty OpenCode response errors** - Empty-body JSON parse failures from the OpenCode server (`SyntaxError: Unexpected end of JSON input`, most commonly caused by an invalid or unavailable `provider/model` ID) are now wrapped in an actionable `APICallError` that names the requested model ID and likely cause. The same wrapping is applied to the streaming prompt failure path, and `modelId` is now included in API call error metadata. (Fixes [#21](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/issues/21), PR [#24](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/pull/24) by [@slegarraga](https://github.com/slegarraga))
+
 ## [3.0.3] - 2026-06-09
 
 ### Fixed

--- a/examples/image-input.ts
+++ b/examples/image-input.ts
@@ -50,7 +50,7 @@ async function main() {
     const mediaType = SUPPORTED_EXTENSIONS[ext]!;
 
     const result = streamText({
-      model: opencode("openai/gpt-5.3-codex"),
+      model: opencode("openai/gpt-5.5"),
       messages: [
         {
           role: "user",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-opencode-sdk",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4815,6 +4815,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite-node/node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/vite-node/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4845,6 +4857,15 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/vite-node/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "7.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-opencode-sdk",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "AI SDK v6 provider for OpenCode via @opencode-ai/sdk",
   "keywords": [
     "ai-sdk",

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -341,6 +341,27 @@ describe("errors", () => {
       expect(result).toBeInstanceOf(APICallError);
     });
 
+    it("should wrap empty JSON responses with model guidance", () => {
+      const error = new SyntaxError("Unexpected end of JSON input");
+      const result = wrapError(error, {
+        sessionId: "session-123",
+        modelId: "github-copilot/gpt-5",
+      });
+
+      expect(result).toBeInstanceOf(APICallError);
+      expect(result.message).toContain(
+        "OpenCode returned an empty JSON response",
+      );
+      expect(result.message).toContain('for model "github-copilot/gpt-5"');
+      expect(result.message).toContain("provider/model");
+      expect((result as APICallError).isRetryable).toBe(false);
+      expect((result as APICallError).data).toMatchObject({
+        errorType: "EmptyJSONResponse",
+        sessionId: "session-123",
+        modelId: "github-copilot/gpt-5",
+      });
+    });
+
     it("should pass metadata through", () => {
       const error = { message: "Error" };
       const result = wrapError(error, { sessionId: "session-123" });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,6 +6,7 @@ import { APICallError, LoadAPIKeyError } from "@ai-sdk/provider";
 export interface OpencodeErrorMetadata {
   sessionId?: string;
   messageId?: string;
+  modelId?: string;
   statusCode?: number;
   isRetryable: boolean;
   errorType?: string;
@@ -175,6 +176,35 @@ export function createAPICallError(
       errorType: metadata?.errorType ?? extractErrorType(error),
       sessionId: metadata?.sessionId,
       messageId: metadata?.messageId,
+      modelId: metadata?.modelId,
+    },
+  });
+}
+
+/**
+ * Create an actionable error for empty JSON responses from OpenCode.
+ */
+function createEmptyResponseError(
+  error: unknown,
+  metadata?: Partial<OpencodeErrorMetadata>,
+): APICallError {
+  const modelHint = metadata?.modelId ? ` for model "${metadata.modelId}"` : "";
+  const originalMessage = extractErrorMessage(error);
+
+  return new APICallError({
+    message:
+      `OpenCode returned an empty JSON response${modelHint}. ` +
+      "This usually means the OpenCode server rejected the request before returning response data, often because the configured provider/model is unavailable or invalid. " +
+      `Check the model ID and OpenCode provider configuration. Original error: ${originalMessage}`,
+    url: "opencode://session",
+    requestBodyValues: {},
+    statusCode: metadata?.statusCode ?? extractStatusCode(error),
+    isRetryable: false,
+    data: {
+      errorType: "EmptyJSONResponse",
+      sessionId: metadata?.sessionId,
+      messageId: metadata?.messageId,
+      modelId: metadata?.modelId,
     },
   });
 }
@@ -357,10 +387,34 @@ export function wrapError(
     return createTimeoutError(timeoutMs, "request");
   }
 
+  if (isEmptyJsonResponseError(error)) {
+    return createEmptyResponseError(error, metadata);
+  }
+
   return createAPICallError(error, metadata);
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 5000;
+
+function isEmptyJsonResponseError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const err = error as Record<string, unknown>;
+  const name =
+    error instanceof SyntaxError
+      ? "SyntaxError"
+      : typeof err.name === "string"
+        ? err.name
+        : undefined;
+
+  return (
+    name === "SyntaxError" &&
+    typeof err.message === "string" &&
+    err.message === "Unexpected end of JSON input"
+  );
+}
 
 function extractTimeoutMs(error: unknown): number | undefined {
   if (!error || typeof error !== "object") {

--- a/src/opencode-language-model.test.ts
+++ b/src/opencode-language-model.test.ts
@@ -337,6 +337,20 @@ describe("opencode-language-model", () => {
       expect(result.request?.body).toBeDefined();
     });
 
+    it("should wrap empty OpenCode JSON responses with model context", async () => {
+      mockClient.session.prompt.mockRejectedValueOnce(
+        new SyntaxError("Unexpected end of JSON input"),
+      );
+
+      await expect(
+        model.doGenerate({
+          prompt: basicPrompt,
+        }),
+      ).rejects.toThrow(
+        'OpenCode returned an empty JSON response for model "anthropic/claude-3-5-sonnet-20241022"',
+      );
+    });
+
     it("should handle JSON mode", async () => {
       await model.doGenerate({
         prompt: basicPrompt,
@@ -1048,7 +1062,10 @@ describe("opencode-language-model", () => {
     });
 
     it("should emit StructuredOutput tool input as text content", async () => {
-      const structuredInput = { output: "# Hello World", outputType: "markdown" };
+      const structuredInput = {
+        output: "# Hello World",
+        outputType: "markdown",
+      };
       mockClient.session.prompt.mockResolvedValueOnce({
         data: {
           info: {
@@ -1093,10 +1110,14 @@ describe("opencode-language-model", () => {
 
       const textParts = result.content.filter((c) => c.type === "text");
       expect(textParts).toHaveLength(1);
-      expect(JSON.parse((textParts[0] as { text: string }).text)).toEqual(structuredInput);
+      expect(JSON.parse((textParts[0] as { text: string }).text)).toEqual(
+        structuredInput,
+      );
 
       const toolCalls = result.content.filter((c) => c.type === "tool-call");
-      const toolResults = result.content.filter((c) => c.type === "tool-result");
+      const toolResults = result.content.filter(
+        (c) => c.type === "tool-result",
+      );
       expect(toolCalls).toHaveLength(0);
       expect(toolResults).toHaveLength(0);
     });
@@ -1149,7 +1170,9 @@ describe("opencode-language-model", () => {
 
       const textParts = result.content.filter((c) => c.type === "text");
       expect(textParts).toHaveLength(1);
-      expect(JSON.parse((textParts[0] as { text: string }).text)).toEqual({ result: "done" });
+      expect(JSON.parse((textParts[0] as { text: string }).text)).toEqual({
+        result: "done",
+      });
     });
 
     it("should not emit tool-call/tool-result for error-status StructuredOutput", async () => {
@@ -1184,7 +1207,9 @@ describe("opencode-language-model", () => {
       });
 
       const toolCalls = result.content.filter((c) => c.type === "tool-call");
-      const toolResults = result.content.filter((c) => c.type === "tool-result");
+      const toolResults = result.content.filter(
+        (c) => c.type === "tool-result",
+      );
       expect(toolCalls).toHaveLength(0);
       expect(toolResults).toHaveLength(0);
     });

--- a/src/opencode-language-model.ts
+++ b/src/opencode-language-model.ts
@@ -274,11 +274,11 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
       };
 
       this.logger.debug?.(
-        `[doGenerate] raw parts from OpenCode: ${JSON.stringify(responseData.parts?.map(p => ({ type: p.type, ...(p.type === 'text' ? { text: (p as any).text?.slice(0, 200) } : {}), ...(p.type === 'tool' ? { tool: (p as any).tool, callID: (p as any).callID, status: (p as any).state?.status, input: (p as any).state?.input } : {}) })))}`,
+        `[doGenerate] raw parts from OpenCode: ${JSON.stringify(responseData.parts?.map((p) => ({ type: p.type, ...(p.type === "text" ? { text: (p as any).text?.slice(0, 200) } : {}), ...(p.type === "tool" ? { tool: (p as any).tool, callID: (p as any).callID, status: (p as any).state?.status, input: (p as any).state?.input } : {}) })))}`,
       );
       const content = this.extractContentFromParts(responseData.parts ?? []);
       this.logger.debug?.(
-        `[doGenerate] extracted content: ${JSON.stringify(content.map(c => ({ type: c.type, ...(c.type === 'text' ? { text: (c as any).text?.slice(0, 200) } : {}), ...(c.type === 'tool-call' ? { toolName: (c as any).toolName } : {}) })))}`,
+        `[doGenerate] extracted content: ${JSON.stringify(content.map((c) => ({ type: c.type, ...(c.type === "text" ? { text: (c as any).text?.slice(0, 200) } : {}), ...(c.type === "tool-call" ? { toolName: (c as any).toolName } : {}) })))}`,
       );
       const usage = this.extractUsageFromParts(responseData.parts ?? []);
       const finishReason = mapOpencodeFinishReason(responseData.info);
@@ -304,6 +304,7 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
 
       throw wrapError(error, {
         sessionId: this.sessionId,
+        modelId: this.modelId,
       });
     }
   }
@@ -418,8 +419,12 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
           }
 
           client.session.prompt(requestBody).catch((error: unknown) => {
-            logger.error(`Prompt error: ${extractErrorMessage(error)}`);
-            controller.enqueue({ type: "error", error });
+            const wrappedError = wrapError(error, {
+              sessionId,
+              modelId: this.modelId,
+            });
+            logger.error(`Prompt error: ${extractErrorMessage(wrappedError)}`);
+            controller.enqueue({ type: "error", error: wrappedError });
             resolvePromptFailed?.();
           });
 
@@ -521,8 +526,12 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
             controller.enqueue(createStreamStartPart(streamWarnings));
           }
           if (!isAbortError(error)) {
-            logger.error(`Stream error: ${extractErrorMessage(error)}`);
-            controller.enqueue({ type: "error", error: wrapError(error) });
+            const wrappedError = wrapError(error, {
+              sessionId,
+              modelId: this.modelId,
+            });
+            logger.error(`Stream error: ${extractErrorMessage(wrappedError)}`);
+            controller.enqueue({ type: "error", error: wrappedError });
           }
         } finally {
           controller.close();
@@ -794,11 +803,14 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
       // `Output.object()` / `Output.array()` can parse it via `step.text`.
       // Emit the tool input as a text part instead of tool-call/tool-result.
       if (toolPart.tool === STRUCTURED_OUTPUT_TOOL) {
-        const serialized = safeStringifyToolInput(toolPart.state.input, (message) => {
-          this.logger.warn(
-            `Failed to serialize StructuredOutput input for ${toolPart.callID}: ${message}`,
-          );
-        });
+        const serialized = safeStringifyToolInput(
+          toolPart.state.input,
+          (message) => {
+            this.logger.warn(
+              `Failed to serialize StructuredOutput input for ${toolPart.callID}: ${message}`,
+            );
+          },
+        );
         this.logger.debug?.(
           `[StructuredOutput doGenerate] callID=${toolPart.callID} status=${toolPart.state.status} raw input=${JSON.stringify(toolPart.state.input)} serialized=${serialized}`,
         );


### PR DESCRIPTION
## Summary

- Converts OpenCode SDK empty-body JSON parse failures into an actionable `APICallError`.
- Includes the requested model ID in the error metadata and diagnostic message so invalid provider/model strings are easier to identify.
- Wraps the same prompt failure path for streaming calls.
- Syncs the lockfile peer entries needed for `npm ci` with the current npm resolver.

Fixes #21.

## Validation

- `npm ci`
- `npm test -- src/errors.test.ts src/opencode-language-model.test.ts`
- `npm run ci`
- `npm run build`
- `npx prettier --check src/errors.ts src/errors.test.ts src/opencode-language-model.ts src/opencode-language-model.test.ts`
- `git diff --check`

Note: `npm run format:check` still reports formatting issues in pre-existing untouched files: `examples/client-options.ts`, `src/opencode-client-manager.test.ts`, `src/opencode-client-manager.ts`, `src/opencode-provider.test.ts`, `src/opencode-provider.ts`, and `src/validation.test.ts`.
