### PR TITLE
style: format with prettier

### DIFF
--- a/examples/client-options.ts
+++ b/examples/client-options.ts
@@ -21,7 +21,10 @@ async function runStep(title: string, fn: () => Promise<void>) {
 
 async function main() {
   console.log("=== OpenCode: clientOptions and preconfigured client ===");
-  console.log("This example assumes an OpenCode server is available at", BASE_URL);
+  console.log(
+    "This example assumes an OpenCode server is available at",
+    BASE_URL,
+  );
   console.log();
 
   const providerWithClientOptions = createOpencode({

--- a/src/opencode-client-manager.test.ts
+++ b/src/opencode-client-manager.test.ts
@@ -265,9 +265,8 @@ describe("opencode-client-manager", () => {
 
       await instance.getClient();
 
-      const { createOpencodeClient, createOpencodeServer } = await import(
-        "@opencode-ai/sdk/v2"
-      );
+      const { createOpencodeClient, createOpencodeServer } =
+        await import("@opencode-ai/sdk/v2");
       expect(createOpencodeClient).toHaveBeenCalledWith(
         expect.objectContaining({
           baseUrl: "http://127.0.0.1:4096",
@@ -315,7 +314,9 @@ describe("opencode-client-manager", () => {
           directory: "/tmp/ignored",
           headers: { "x-test": "value" },
         } as unknown as NonNullable<
-          Parameters<typeof import("@opencode-ai/sdk/v2").createOpencodeClient>[0]
+          Parameters<
+            typeof import("@opencode-ai/sdk/v2").createOpencodeClient
+          >[0]
         >,
         logger: {
           warn,
@@ -350,7 +351,9 @@ describe("opencode-client-manager", () => {
           directory: undefined,
           headers: { "x-test": "value" },
         } as unknown as NonNullable<
-          Parameters<typeof import("@opencode-ai/sdk/v2").createOpencodeClient>[0]
+          Parameters<
+            typeof import("@opencode-ai/sdk/v2").createOpencodeClient
+          >[0]
         >,
         logger: {
           warn,
@@ -396,9 +399,8 @@ describe("opencode-client-manager", () => {
 
       const client = await instance.getClient();
 
-      const { createOpencodeClient, createOpencodeServer } = await import(
-        "@opencode-ai/sdk/v2"
-      );
+      const { createOpencodeClient, createOpencodeServer } =
+        await import("@opencode-ai/sdk/v2");
       expect(client).toBe(preconfiguredClient);
       expect(createOpencodeClient).not.toHaveBeenCalled();
       expect(createOpencodeServer).not.toHaveBeenCalled();

--- a/src/opencode-client-manager.ts
+++ b/src/opencode-client-manager.ts
@@ -271,7 +271,9 @@ export class OpencodeClientManager {
   /**
    * Build client options with manager-owned baseUrl and directory.
    */
-  private createManagedClientOptions(baseUrl: string): OpencodeCreateClientOptions {
+  private createManagedClientOptions(
+    baseUrl: string,
+  ): OpencodeCreateClientOptions {
     const options = this.options.clientOptions ?? {};
     const optionsRecord = options as Record<string, unknown>;
 

--- a/src/opencode-provider.test.ts
+++ b/src/opencode-provider.test.ts
@@ -116,9 +116,8 @@ describe("opencode-provider", () => {
         >,
       });
 
-      const { createClientManagerFromSettings } = await import(
-        "./opencode-client-manager.js"
-      );
+      const { createClientManagerFromSettings } =
+        await import("./opencode-client-manager.js");
       expect(createClientManagerFromSettings).toHaveBeenCalledWith(
         expect.objectContaining({
           baseUrl: "http://custom:8080",

--- a/src/opencode-provider.ts
+++ b/src/opencode-provider.ts
@@ -44,7 +44,9 @@ export function createOpencode(
   validateProviderSettings(options, logger);
 
   // Use explicit client manager if provided, otherwise use singleton
-  const clientManager = options?.clientManager ?? createClientManagerFromSettings(options ?? {}, logger);
+  const clientManager =
+    options?.clientManager ??
+    createClientManagerFromSettings(options ?? {}, logger);
 
   /**
    * Create a language model instance.

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -132,7 +132,9 @@ describe("validation", () => {
       const result = validateProviderSettings(settings);
       expect(
         result.warnings.some(
-          (w) => w.includes("client and clientOptions") || w.includes("clientOptions"),
+          (w) =>
+            w.includes("client and clientOptions") ||
+            w.includes("clientOptions"),
         ),
       ).toBe(true);
     });
@@ -153,7 +155,8 @@ describe("validation", () => {
       ).toBe(true);
       expect(
         result.warnings.some(
-          (w) => w.includes("clientOptions.directory") || w.includes("directory"),
+          (w) =>
+            w.includes("clientOptions.directory") || w.includes("directory"),
         ),
       ).toBe(true);
     });
@@ -177,7 +180,8 @@ describe("validation", () => {
       ).toBe(false);
       expect(
         result.warnings.some(
-          (w) => w.includes("clientOptions.directory") || w.includes("directory"),
+          (w) =>
+            w.includes("clientOptions.directory") || w.includes("directory"),
         ),
       ).toBe(false);
     });


### PR DESCRIPTION
Runs `npm run format` across the repo. Pure line-wrapping reflow of the 6 files that currently fail `npm run format:check` — no semantic changes.

Verified locally: `npm run ci` (typecheck + lint + 358 tests) passes, and `prettier --check .` is now clean.

This unblocks adding `npm run format:check` as a blocking step in the upcoming CI workflow PR, so it should merge first.