### PR TITLE
fix: surface actionable error when OpenCode prompt returns no response data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.5] - 2026-06-11
 
+### Added
+
+- **Exported `createEmptyResponseDataError`** - New error factory alongside the existing `createAPICallError` / `createTimeoutError` exports.
+
 ### Fixed
 
+- **Empty response data errors** - Prompt calls that succeed but return no response data (the behavior of opencode CLI 1.17.x for invalid or unavailable `provider/model` IDs, e.g. the `github-copilot/gpt-5` repro from [#21](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk/issues/21)) now throw an actionable `APICallError` that names the requested model ID, suggests checking `opencode models`, includes the server error payload when available, and carries `errorType: "EmptyResponseData"` — replacing the generic `No response data from OpenCode`. The streaming path surfaces the same error as an `error` stream part and terminates the stream instead of hanging on the event subscription.
+- **`wrapError` double-wrapping** - `wrapError` now returns already-wrapped AI SDK errors (`APICallError`, `LoadAPIKeyError`) unchanged instead of re-wrapping them and losing their metadata.
 - **Singleton client manager recovery after dispose** - `OpencodeClientManager.dispose()` now releases the singleton slot when the disposed manager is the singleton, so a later `createOpencode()` builds a fresh client manager. Previously the singleton kept pointing at the disposed instance, and every subsequent provider in the same process failed with `Client manager has been disposed`.
 - **client-options example** - Step 2 of `examples/client-options.ts` now genuinely demonstrates the preconfigured-client pattern by passing an isolated manager via `clientManager: OpencodeClientManager.createInstance({ client })`. Previously the preconfigured client was handed to the singleton that step 1 had already initialized, so it was ignored and step 2's requests flowed through step 1's client while the demo reported success. The example now also echoes each outgoing request's `x-demo-source` header so the output proves which client served it, drops a spurious `await` on the synchronous v2 `createOpencodeClient()`, and allows overriding the example model via `OPENCODE_MODEL`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Clearer stale-options warnings** - The client manager's "already initialized" warnings now point at the escape hatches that actually work (`OpencodeClientManager.createInstance()` with the `clientManager` provider setting, or `OpencodeClientManager.resetInstance()`) instead of the previous generic advice.
+- **`clientOptions.responseStyle` normalization** - Managed clients are now always created with fields-style SDK results; `clientOptions.responseStyle: "data"` is ignored with a warning since the provider's response handling requires `{ data, error }` results. Prompt-result handling also tolerates data-style results from caller-supplied (preconfigured) clients.
 
 ## [3.0.4] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Clearer stale-options warnings** - The client manager's "already initialized" warnings now point at the escape hatches that actually work (`OpencodeClientManager.createInstance()` with the `clientManager` provider setting, or `OpencodeClientManager.resetInstance()`) instead of the previous generic advice.
-- **`clientOptions.responseStyle` normalization** - Managed clients are now always created with fields-style SDK results; `clientOptions.responseStyle: "data"` is ignored with a warning since the provider's response handling requires `{ data, error }` results. Prompt-result handling also tolerates data-style results from caller-supplied (preconfigured) clients.
+- **`clientOptions.responseStyle` normalization** - Managed clients are now always created with fields-style SDK results; `clientOptions.responseStyle: "data"` is ignored with a warning since the provider's response handling requires `{ data, error }` results. Session-creation and prompt result handling also tolerate data-style results from caller-supplied (preconfigured) clients.
 
 ## [3.0.4] - 2026-06-11
 

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -6,6 +6,7 @@ import {
   isOutputLengthError,
   createAuthenticationError,
   createAPICallError,
+  createEmptyResponseDataError,
   createTimeoutError,
   extractErrorMessage,
   wrapError,
@@ -240,6 +241,45 @@ describe("errors", () => {
     });
   });
 
+  describe("createEmptyResponseDataError", () => {
+    it("should create actionable error with model guidance", () => {
+      const result = createEmptyResponseDataError(undefined, {
+        sessionId: "session-123",
+        modelId: "github-copilot/gpt-5",
+      });
+
+      expect(result).toBeInstanceOf(APICallError);
+      expect(result.message).toContain("OpenCode returned no response data");
+      expect(result.message).toContain('for model "github-copilot/gpt-5"');
+      expect(result.message).toContain("provider/model");
+      expect(result.message).toContain("opencode models");
+      expect(result.isRetryable).toBe(false);
+      expect(result.data).toMatchObject({
+        errorType: "EmptyResponseData",
+        sessionId: "session-123",
+        modelId: "github-copilot/gpt-5",
+      });
+    });
+
+    it("should omit model hint when modelId is missing", () => {
+      const result = createEmptyResponseDataError(undefined);
+
+      expect(result.message).toContain("OpenCode returned no response data");
+      expect(result.message).not.toContain("for model");
+      expect(result.message).not.toContain("Original error");
+    });
+
+    it("should include original error details when available", () => {
+      const result = createEmptyResponseDataError(
+        { message: "model not found", statusCode: 400 },
+        { modelId: "github-copilot/gpt-5" },
+      );
+
+      expect(result.message).toContain("Original error: model not found");
+      expect(result.statusCode).toBe(400);
+    });
+  });
+
   describe("createTimeoutError", () => {
     it("should create timeout error with duration", () => {
       const result = createTimeoutError(5000);
@@ -367,6 +407,20 @@ describe("errors", () => {
       const result = wrapError(error, { sessionId: "session-123" });
 
       expect((result as APICallError).data).toMatchObject({
+        sessionId: "session-123",
+      });
+    });
+
+    it("should return already-wrapped AI SDK errors unchanged", () => {
+      const original = createEmptyResponseDataError(undefined, {
+        sessionId: "session-123",
+        modelId: "github-copilot/gpt-5",
+      });
+      const result = wrapError(original, { sessionId: "other-session" });
+
+      expect(result).toBe(original);
+      expect((result as APICallError).data).toMatchObject({
+        errorType: "EmptyResponseData",
         sessionId: "session-123",
       });
     });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -210,6 +210,36 @@ function createEmptyResponseError(
 }
 
 /**
+ * Create an actionable error for OpenCode responses that complete without
+ * any response data.
+ */
+export function createEmptyResponseDataError(
+  error: unknown,
+  metadata?: Partial<OpencodeErrorMetadata>,
+): APICallError {
+  const modelHint = metadata?.modelId ? ` for model "${metadata.modelId}"` : "";
+  const detail = error ? ` Original error: ${extractErrorMessage(error)}` : "";
+
+  return new APICallError({
+    message:
+      `OpenCode returned no response data${modelHint}. ` +
+      "This usually means the configured provider/model ID is invalid or unavailable. " +
+      "Run `opencode models` to list available model IDs and check the OpenCode provider configuration." +
+      detail,
+    url: "opencode://session",
+    requestBodyValues: {},
+    statusCode: metadata?.statusCode ?? extractStatusCode(error),
+    isRetryable: false,
+    data: {
+      errorType: "EmptyResponseData",
+      sessionId: metadata?.sessionId,
+      messageId: metadata?.messageId,
+      modelId: metadata?.modelId,
+    },
+  });
+}
+
+/**
  * Create a timeout error.
  */
 export function createTimeoutError(
@@ -375,6 +405,11 @@ export function wrapError(
   error: unknown,
   metadata?: Partial<OpencodeErrorMetadata>,
 ): Error {
+  // Errors created by this module are already actionable AI SDK errors.
+  if (APICallError.isInstance(error) || LoadAPIKeyError.isInstance(error)) {
+    return error;
+  }
+
   if (isAuthenticationError(error)) {
     return createAuthenticationError(error);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export {
   isOutputLengthError,
   createAuthenticationError,
   createAPICallError,
+  createEmptyResponseDataError,
   createTimeoutError,
   extractErrorMessage,
   wrapError,

--- a/src/opencode-client-manager.test.ts
+++ b/src/opencode-client-manager.test.ts
@@ -341,6 +341,33 @@ describe("opencode-client-manager", () => {
       );
     });
 
+    it('should force fields responseStyle and warn when clientOptions requests "data"', async () => {
+      const warn = vi.fn();
+
+      const instance = OpencodeClientManager.getInstance({
+        baseUrl: "http://custom-server:8080",
+        clientOptions: {
+          responseStyle: "data",
+        },
+        logger: {
+          warn,
+          error: vi.fn(),
+        },
+      });
+
+      await instance.getClient();
+
+      const { createOpencodeClient } = await import("@opencode-ai/sdk/v2");
+      expect(createOpencodeClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          responseStyle: "fields",
+        }),
+      );
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Ignoring clientOptions.responseStyle"),
+      );
+    });
+
     it("should not warn for undefined reserved keys in clientOptions", async () => {
       const warn = vi.fn();
 

--- a/src/opencode-client-manager.ts
+++ b/src/opencode-client-manager.ts
@@ -287,11 +287,17 @@ export class OpencodeClientManager {
         "Ignoring clientOptions.directory because directory is managed by model settings/defaultSettings.",
       );
     }
+    if (optionsRecord.responseStyle === "data") {
+      this.logger.warn(
+        'Ignoring clientOptions.responseStyle "data" because the provider requires fields-style SDK results.',
+      );
+    }
 
     return {
       ...options,
       baseUrl,
       directory: this.options.cwd,
+      responseStyle: "fields",
     };
   }
 

--- a/src/opencode-language-model.test.ts
+++ b/src/opencode-language-model.test.ts
@@ -384,6 +384,27 @@ describe("opencode-language-model", () => {
       ).rejects.toThrow("Original error: model not found");
     });
 
+    it("should handle data-style session creation results from custom clients", async () => {
+      // A caller-supplied client configured with responseStyle: "data"
+      // resolves session.create to the session payload itself.
+      mockClient.session.create.mockResolvedValueOnce({
+        id: "session-data-style",
+      });
+
+      const result = await model.doGenerate({
+        prompt: basicPrompt,
+      });
+
+      expect(result.providerMetadata?.opencode?.sessionId).toBe(
+        "session-data-style",
+      );
+      expect(mockClient.session.prompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionID: "session-data-style",
+        }),
+      );
+    });
+
     it("should handle data-style prompt results from custom clients", async () => {
       // A caller-supplied client configured with responseStyle: "data"
       // resolves session.prompt to the payload itself.

--- a/src/opencode-language-model.test.ts
+++ b/src/opencode-language-model.test.ts
@@ -351,6 +351,39 @@ describe("opencode-language-model", () => {
       );
     });
 
+    it("should wrap missing OpenCode response data with model context", async () => {
+      mockClient.session.prompt.mockResolvedValueOnce({ data: undefined });
+
+      await expect(
+        model.doGenerate({
+          prompt: basicPrompt,
+        }),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining(
+          'OpenCode returned no response data for model "anthropic/claude-3-5-sonnet-20241022"',
+        ),
+        isRetryable: false,
+        data: expect.objectContaining({
+          errorType: "EmptyResponseData",
+          sessionId: "session-123",
+          modelId: "anthropic/claude-3-5-sonnet-20241022",
+        }),
+      });
+    });
+
+    it("should include response error details when response data is missing", async () => {
+      mockClient.session.prompt.mockResolvedValueOnce({
+        data: undefined,
+        error: { message: "model not found" },
+      });
+
+      await expect(
+        model.doGenerate({
+          prompt: basicPrompt,
+        }),
+      ).rejects.toThrow("Original error: model not found");
+    });
+
     it("should handle JSON mode", async () => {
       await model.doGenerate({
         prompt: basicPrompt,
@@ -873,6 +906,67 @@ describe("opencode-language-model", () => {
 
       expect(parts[0]).toMatchObject({ type: "stream-start" });
       expect(parts.some((part: any) => part.type === "error")).toBe(true);
+      expect(iteratorReturn).toHaveBeenCalled();
+    });
+
+    it("should emit actionable error when prompt resolves without data", async () => {
+      const iteratorReturn = vi
+        .fn<() => Promise<IteratorResult<unknown>>, []>()
+        .mockResolvedValue({ done: true, value: undefined });
+
+      const hangingStream: AsyncIterable<unknown> = {
+        [Symbol.asyncIterator]() {
+          return {
+            next() {
+              return new Promise<IteratorResult<unknown>>(() => {
+                // Intentionally never resolves to emulate server silence.
+              });
+            },
+            return: iteratorReturn,
+          };
+        },
+      };
+
+      mockClient.event.subscribe.mockResolvedValueOnce({
+        stream: hangingStream,
+      });
+      mockClient.session.prompt.mockResolvedValueOnce({ data: undefined });
+
+      const result = await model.doStream({
+        prompt: basicPrompt,
+      });
+
+      const reader = result.stream.getReader();
+      const parts = await new Promise<unknown[]>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error("Timed out waiting for stream to close"));
+        }, 500);
+
+        (async () => {
+          const streamParts: unknown[] = [];
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            streamParts.push(value);
+          }
+          clearTimeout(timeout);
+          resolve(streamParts);
+        })().catch((error: unknown) => {
+          clearTimeout(timeout);
+          reject(error);
+        });
+      });
+
+      const errorPart = parts.find((part: any) => part.type === "error") as
+        | { error?: { message?: string; data?: { errorType?: string } } }
+        | undefined;
+      expect(errorPart).toBeDefined();
+      expect(errorPart?.error?.message).toContain(
+        'OpenCode returned no response data for model "anthropic/claude-3-5-sonnet-20241022"',
+      );
+      expect(errorPart?.error?.data).toMatchObject({
+        errorType: "EmptyResponseData",
+      });
       expect(iteratorReturn).toHaveBeenCalled();
     });
 

--- a/src/opencode-language-model.test.ts
+++ b/src/opencode-language-model.test.ts
@@ -384,6 +384,47 @@ describe("opencode-language-model", () => {
       ).rejects.toThrow("Original error: model not found");
     });
 
+    it("should handle data-style prompt results from custom clients", async () => {
+      // A caller-supplied client configured with responseStyle: "data"
+      // resolves session.prompt to the payload itself.
+      mockClient.session.prompt.mockResolvedValueOnce({
+        info: {
+          id: "msg-1",
+          sessionID: "session-123",
+          role: "assistant",
+          finish: "end_turn",
+        },
+        parts: [{ id: "part-1", type: "text", text: "Hello, world!" }],
+      });
+
+      const result = await model.doGenerate({
+        prompt: basicPrompt,
+      });
+
+      expect(result.content[0]).toMatchObject({
+        type: "text",
+        text: "Hello, world!",
+      });
+    });
+
+    it("should wrap undefined data-style prompt results with model context", async () => {
+      // A responseStyle: "data" client resolves to undefined on failure.
+      mockClient.session.prompt.mockResolvedValueOnce(undefined);
+
+      await expect(
+        model.doGenerate({
+          prompt: basicPrompt,
+        }),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining(
+          'OpenCode returned no response data for model "anthropic/claude-3-5-sonnet-20241022"',
+        ),
+        data: expect.objectContaining({
+          errorType: "EmptyResponseData",
+        }),
+      });
+    });
+
     it("should handle JSON mode", async () => {
       await model.doGenerate({
         prompt: basicPrompt,
@@ -968,6 +1009,58 @@ describe("opencode-language-model", () => {
         errorType: "EmptyResponseData",
       });
       expect(iteratorReturn).toHaveBeenCalled();
+    });
+
+    it("should not flag data-style prompt results as missing data", async () => {
+      mockClient.event.subscribe.mockResolvedValueOnce({
+        stream: (async function* () {
+          yield {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "part-1",
+                sessionID: "session-123",
+                messageID: "msg-1",
+                type: "text",
+                text: "Hello",
+              },
+              delta: "Hello",
+            },
+          };
+          yield {
+            type: "session.idle",
+            properties: {
+              sessionID: "session-123",
+            },
+          };
+        })(),
+      });
+      // A caller-supplied client configured with responseStyle: "data"
+      // resolves session.prompt to the payload itself.
+      mockClient.session.prompt.mockResolvedValueOnce({
+        info: {
+          id: "msg-1",
+          sessionID: "session-123",
+          role: "assistant",
+          finish: "end_turn",
+        },
+        parts: [{ id: "part-1", type: "text", text: "Hello" }],
+      });
+
+      const result = await model.doStream({
+        prompt: basicPrompt,
+      });
+
+      const parts: unknown[] = [];
+      const reader = result.stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        parts.push(value);
+      }
+
+      expect(parts.some((part: any) => part.type === "error")).toBe(false);
+      expect(parts.some((part: any) => part.type === "finish")).toBe(true);
     });
 
     it("should terminate stream when abort signal fires without incoming events", async () => {

--- a/src/opencode-language-model.ts
+++ b/src/opencode-language-model.ts
@@ -91,12 +91,12 @@ function convertUsage(usage: StreamingUsage): LanguageModelV3Usage {
 }
 
 /**
- * Normalize a session.prompt result. Managed clients resolve to a
+ * Normalize an SDK request result. Managed clients resolve to a
  * fields-style result ({ data, error }), but a caller-supplied client may be
  * configured with responseStyle: "data", which resolves to the payload
  * itself (or undefined on failure).
  */
-function extractPromptResult(result: unknown): {
+function extractSdkResult(result: unknown): {
   data?: unknown;
   error?: unknown;
 } {
@@ -289,7 +289,7 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
 
       const result = await client.session.prompt(requestBody);
 
-      const { data, error: responseError } = extractPromptResult(result);
+      const { data, error: responseError } = extractSdkResult(result);
       if (!data) {
         throw createEmptyResponseDataError(responseError, {
           sessionId,
@@ -464,7 +464,7 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
           };
 
           client.session.prompt(requestBody).then((result) => {
-            const { data, error: responseError } = extractPromptResult(result);
+            const { data, error: responseError } = extractSdkResult(result);
             if (!data) {
               handlePromptFailure(
                 createEmptyResponseDataError(responseError, {
@@ -754,10 +754,11 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
           : {}),
       });
 
-      const data = result.data as { id: string } | undefined;
+      const { data: createData, error: createError } = extractSdkResult(result);
+      const data = createData as { id: string } | undefined;
       if (!data?.id) {
         throw new Error(
-          `Failed to create session: ${JSON.stringify(result.error ?? result.data)}`,
+          `Failed to create session: ${JSON.stringify(createError ?? createData)}`,
         );
       }
 

--- a/src/opencode-language-model.ts
+++ b/src/opencode-language-model.ts
@@ -90,6 +90,27 @@ function convertUsage(usage: StreamingUsage): LanguageModelV3Usage {
   };
 }
 
+/**
+ * Normalize a session.prompt result. Managed clients resolve to a
+ * fields-style result ({ data, error }), but a caller-supplied client may be
+ * configured with responseStyle: "data", which resolves to the payload
+ * itself (or undefined on failure).
+ */
+function extractPromptResult(result: unknown): {
+  data?: unknown;
+  error?: unknown;
+} {
+  if (
+    result &&
+    typeof result === "object" &&
+    ("data" in result || "error" in result)
+  ) {
+    return result as { data?: unknown; error?: unknown };
+  }
+
+  return { data: result };
+}
+
 function getMessageIDFromProviderOptions(
   options: LanguageModelV3CallOptions,
 ): string | undefined {
@@ -268,9 +289,9 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
 
       const result = await client.session.prompt(requestBody);
 
-      const data = result.data;
+      const { data, error: responseError } = extractPromptResult(result);
       if (!data) {
-        throw createEmptyResponseDataError(result.error, {
+        throw createEmptyResponseDataError(responseError, {
           sessionId,
           modelId: this.modelId,
         });
@@ -443,9 +464,10 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
           };
 
           client.session.prompt(requestBody).then((result) => {
-            if (!result.data) {
+            const { data, error: responseError } = extractPromptResult(result);
+            if (!data) {
               handlePromptFailure(
-                createEmptyResponseDataError(result.error, {
+                createEmptyResponseDataError(responseError, {
                   sessionId,
                   modelId: this.modelId,
                 }),

--- a/src/opencode-language-model.ts
+++ b/src/opencode-language-model.ts
@@ -32,7 +32,12 @@ import {
 import { mapOpencodeFinishReason } from "./map-opencode-finish-reason.js";
 import { getLogger, logUnsupportedCallOptions } from "./logger.js";
 import { validateModelId, validateSettings } from "./validation.js";
-import { wrapError, extractErrorMessage, isAbortError } from "./errors.js";
+import {
+  wrapError,
+  extractErrorMessage,
+  isAbortError,
+  createEmptyResponseDataError,
+} from "./errors.js";
 import {
   safeStringifyToolInput,
   planFilePartConversion,
@@ -265,7 +270,10 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
 
       const data = result.data;
       if (!data) {
-        throw new Error("No response data from OpenCode");
+        throw createEmptyResponseDataError(result.error, {
+          sessionId,
+          modelId: this.modelId,
+        });
       }
 
       const responseData = data as {
@@ -418,15 +426,32 @@ export class OpencodeLanguageModel implements LanguageModelV3 {
             }
           }
 
-          client.session.prompt(requestBody).catch((error: unknown) => {
+          const handlePromptFailure = (error: unknown) => {
             const wrappedError = wrapError(error, {
               sessionId,
               modelId: this.modelId,
             });
             logger.error(`Prompt error: ${extractErrorMessage(wrappedError)}`);
-            controller.enqueue({ type: "error", error: wrappedError });
+            try {
+              controller.enqueue({ type: "error", error: wrappedError });
+            } catch (enqueueError) {
+              logger.debug?.(
+                `Failed to enqueue prompt error after stream closed: ${extractErrorMessage(enqueueError)}`,
+              );
+            }
             resolvePromptFailed?.();
-          });
+          };
+
+          client.session.prompt(requestBody).then((result) => {
+            if (!result.data) {
+              handlePromptFailure(
+                createEmptyResponseDataError(result.error, {
+                  sessionId,
+                  modelId: this.modelId,
+                }),
+              );
+            }
+          }, handlePromptFailure);
 
           const state = createStreamState();
           let lastMessageInfo: Message | undefined;


### PR DESCRIPTION
## Summary

Extends the actionable error guidance from #24 to the no-data branch. On opencode CLI 1.17.x, an invalid or unavailable `provider/model` ID (e.g. `github-copilot/gpt-5`, the exact repro from #21) no longer produces an empty HTTP body — the SDK call succeeds but `result.data` is falsy, bypassing #24's `EmptyJSONResponse` wrapping and hitting the generic `No response data from OpenCode` error (errorType `"Error"`, no guidance).

## Changes

- **`doGenerate`**: the no-data branch now throws an `APICallError` naming the model ID, suggesting `opencode models`, including the server error payload (`result.error`) when available, and carrying `errorType: "EmptyResponseData"` with `isRetryable: false`.
- **`doStream`**: a prompt that resolves with no data previously left the stream hanging forever on the event subscription. It now surfaces the same actionable error as an `error` stream part and terminates the stream. The error enqueue is also guarded against an already-closed controller (the prompt promise routinely settles after `session.idle` closes the stream).
- **`wrapError`**: now returns already-wrapped AI SDK errors (`APICallError`, `LoadAPIKeyError`) unchanged instead of re-wrapping them and losing their metadata. Needed because the new error is thrown inside `doGenerate`'s try block whose catch funnels everything through `wrapError`; also fixes double-wrapping for direct callers.
- **Exports**: new `createEmptyResponseDataError` factory exported alongside `createAPICallError` / `createTimeoutError`.
- **Tests**: mirror the #24 coverage — `createEmptyResponseDataError` unit tests and a `wrapError` pass-through test in `errors.test.ts`; `doGenerate` no-data and server-error-detail tests plus a `doStream` hanging-stream test in `opencode-language-model.test.ts`.
- **CHANGELOG**: entries added to the existing unreleased `[3.0.5]` section (no version bump here — main is already at 3.0.5 from #27; this work ships in that release).

## Verification

Tested against `dist/` with opencode CLI 1.17.3 and the invalid model `github-copilot/gpt-5`. Both `generateText` and `streamText` now produce:

> OpenCode returned no response data for model "github-copilot/gpt-5". This usually means the configured provider/model ID is invalid or unavailable. Run `opencode models` to list available model IDs and check the OpenCode provider configuration. Original error: Unexpected server error. Check server logs for details.

with `data.errorType: "EmptyResponseData"`, and the streaming call terminates instead of hanging.

`npm run format:check` and `npm run ci` (typecheck, lint, 366 tests) pass locally.

Refs #21, follows up on #24.